### PR TITLE
add "/debug" endpoint for pprof support

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -88,7 +88,6 @@ core,"github.com/operator-framework/operator-sdk/internal/util/yamlutil",Apache-
 core,"github.com/operator-framework/operator-sdk/pkg/k8sutil",Apache-2.0
 core,"github.com/operator-framework/operator-sdk/pkg/leader",Apache-2.0
 core,"github.com/operator-framework/operator-sdk/pkg/log/zap",Apache-2.0
-core,"github.com/operator-framework/operator-sdk/pkg/metrics",Apache-2.0
 core,"github.com/operator-framework/operator-sdk/pkg/restmapper",Apache-2.0
 core,"github.com/operator-framework/operator-sdk/pkg/test",Apache-2.0
 core,"github.com/operator-framework/operator-sdk/pkg/test/e2eutil",Apache-2.0

--- a/chart/extendeddaemonset/templates/deployment.yaml
+++ b/chart/extendeddaemonset/templates/deployment.yaml
@@ -31,6 +31,9 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
             - --zap-level={{ .Values.logLevel }}
+          {{- if .Values.pprof.enabled }}
+            - --pprof=true
+          {{- end }}
           env:  
             - name: WATCH_NAMESPACE
           {{- if .Values.clusterScope }}

--- a/chart/extendeddaemonset/values.yaml
+++ b/chart/extendeddaemonset/values.yaml
@@ -17,6 +17,9 @@ logLevel: "info"
 # Defaulted to false
 clusterScope: false
 
+pprof:
+  enabled: false
+
 rbac:
   # Specifies whether the RBAC resources should be created
   create: true

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/hako/durafmt v0.0.0-20191009132224-3f39dc1ed9f4
 	github.com/olekukonko/tablewriter v0.0.2
 	github.com/operator-framework/operator-sdk v0.12.0
+	github.com/prometheus/client_golang v1.0.0
 	github.com/prometheus/common v0.4.1
 	github.com/spf13/cobra v0.0.5
 	github.com/spf13/pflag v1.0.3

--- a/pkg/controller/debug/register.go
+++ b/pkg/controller/debug/register.go
@@ -11,7 +11,7 @@ import (
 	"github.com/datadog/extendeddaemonset/pkg/controller/httpserver"
 )
 
-// Options use to provide configuration option
+// Options used to provide configuration options
 type Options struct {
 	CmdLine bool
 	Profile bool

--- a/pkg/controller/debug/register.go
+++ b/pkg/controller/debug/register.go
@@ -29,7 +29,7 @@ func DefaultOptions() *Options {
 	}
 }
 
-// Register use to register the different debug endpoint
+// Register used to register the different debug endpoints
 func Register(mux httpserver.Server, options *Options) {
 	mux.HandleFunc("/debug/pprof/", pprof.Index)
 	if options == nil {

--- a/pkg/controller/debug/register.go
+++ b/pkg/controller/debug/register.go
@@ -1,0 +1,50 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2019 Datadog, Inc.
+
+package debug
+
+import (
+	"net/http/pprof"
+
+	"github.com/datadog/extendeddaemonset/pkg/controller/httpserver"
+)
+
+// Options use to provide configuration option
+type Options struct {
+	CmdLine bool
+	Profile bool
+	Symbol  bool
+	Trace   bool
+}
+
+// DefaultOptions returns default options configuration
+func DefaultOptions() *Options {
+	return &Options{
+		CmdLine: true,
+		Profile: true,
+		Symbol:  true,
+		Trace:   true,
+	}
+}
+
+// Register use to register the different debug endpoint
+func Register(mux httpserver.Server, options *Options) {
+	mux.HandleFunc("/debug/pprof/", pprof.Index)
+	if options == nil {
+		options = DefaultOptions()
+	}
+	if options.CmdLine {
+		mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+	}
+	if options.Profile {
+		mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
+	}
+	if options.Symbol {
+		mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+	}
+	if options.Trace {
+		mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
+	}
+}

--- a/pkg/controller/httpserver/runner.go
+++ b/pkg/controller/httpserver/runner.go
@@ -1,0 +1,101 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2019 Datadog, Inc.
+
+package httpserver
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+)
+
+var log = logf.Log.WithName("httpserver")
+
+// DefaultBindAddress sets the default bind address for the HTTP server listener
+var DefaultBindAddress = ":8080"
+
+// Options use to provides Runner creation options
+type Options struct {
+	BindAddress string
+}
+
+// Server inferface for the http server
+// Allows to register http.Hander and http.HandlerFunc
+type Server interface {
+	manager.Runnable
+	Handle(path string, handler http.Handler)
+	HandleFunc(path string, handlerFunc http.HandlerFunc)
+}
+
+// server HTTP debug server
+type server struct {
+	bindAddress string
+
+	mux *http.ServeMux
+}
+
+// New returns new Runner instance
+func New(options Options) Server {
+	return &server{
+		bindAddress: options.BindAddress,
+		mux:         http.NewServeMux(),
+	}
+}
+
+// Handle registers the handler for the given pattern.
+// If a handler already exists for pattern, Handle panics.
+func (s *server) Handle(path string, handler http.Handler) {
+	s.mux.Handle(path, handler)
+}
+
+// HandleFunc registers the handler function for the given pattern
+// in the DefaultServeMux.
+// The documentation for ServeMux explains how patterns are matched.
+func (s *server) HandleFunc(path string, handlerFunc http.HandlerFunc) {
+	s.mux.HandleFunc(path, handlerFunc)
+}
+
+// Start use to start the HTTP server
+func (s *server) Start(stop <-chan struct{}) error {
+	listener, err := newListener(s.bindAddress)
+	if err != nil {
+		return err
+	}
+	server := http.Server{
+		Handler: s.mux,
+	}
+	// Run the server
+	go func() {
+		log.Info("starting http server")
+		if err := server.Serve(listener); err != nil && err != http.ErrServerClosed {
+			log.Error(err, "http server error")
+		}
+	}()
+
+	// Shutdown the server when stop is close
+	<-stop
+	return server.Shutdown(context.Background())
+}
+
+// newListener creates a new TCP listener bound to the given address.
+func newListener(addr string) (net.Listener, error) {
+	if addr == "" {
+		// If the metrics bind address is empty, default to ":8080"
+		addr = DefaultBindAddress
+	}
+
+	log.Info("debug server is starting to listen", "addr", addr)
+	ln, err := net.Listen("tcp", addr)
+	if err != nil {
+		er := fmt.Errorf("error listening on %s: %v", addr, err)
+		log.Error(er, "debug server failed to listen. You may want to disable the debug server or use another port if it is due to conflicts")
+		return nil, er
+	}
+	return ln, nil
+}

--- a/pkg/controller/metrics/register.go
+++ b/pkg/controller/metrics/register.go
@@ -1,0 +1,23 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2019 Datadog, Inc.
+
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+
+	"github.com/datadog/extendeddaemonset/pkg/controller/httpserver"
+)
+
+// Register used to register Metrics handler in the http server
+func Register(mux httpserver.Server) {
+	var metricsPath = "/metrics"
+	handler := promhttp.HandlerFor(metrics.Registry, promhttp.HandlerOpts{
+		ErrorHandling: promhttp.HTTPErrorOnError,
+	})
+	mux.Handle(metricsPath, handler)
+}


### PR DESCRIPTION
This PR introduce the possibility to enable `pprof` behind the "/debug" endpoint in the extendeddaemonset endpoint.

* add args --pprof to activate `/debug` endpoint (false by default)
* add args --pprof-bind-address to list on a specific address and port
* remove the metrics k8s service creation