### PR TITLE
Prevent ExtendedDaemonSet from being stuck because of an unhealthy node

### DIFF
--- a/chart/extendeddaemonset/templates/datadoghq.com_extendeddaemonsetreplicasets_crd.yaml
+++ b/chart/extendeddaemonset/templates/datadoghq.com_extendeddaemonsetreplicasets_crd.yaml
@@ -19,6 +19,9 @@ spec:
   - JSONPath: .status.available
     name: available
     type: integer
+  - JSONPath: .status.ignoredunresponsivenodes
+    name: ignored unresponsive nodes
+    type: integer
   - JSONPath: .spec.selector
     name: node selector
     type: string
@@ -5894,6 +5897,9 @@ spec:
             desired:
               format: int32
               type: integer
+            ignoredunresponsivenodes:
+              format: int32
+              type: integer
             ready:
               format: int32
               type: integer
@@ -5903,6 +5909,7 @@ spec:
           - available
           - current
           - desired
+          - ignoredunresponsivenodes
           - ready
           - status
           type: object

--- a/chart/extendeddaemonset/templates/datadoghq.com_extendeddaemonsets_crd.yaml
+++ b/chart/extendeddaemonset/templates/datadoghq.com_extendeddaemonsets_crd.yaml
@@ -19,6 +19,9 @@ spec:
   - JSONPath: .status.available
     name: available
     type: integer
+  - JSONPath: .status.ignoredunresponsivenodes
+    name: ignored unresponsive nodes
+    type: integer
   - JSONPath: .status.state
     name: status
     type: string
@@ -5886,6 +5889,9 @@ spec:
             desired:
               format: int32
               type: integer
+            ignoredunresponsivenodes:
+              format: int32
+              type: integer
             ready:
               format: int32
               type: integer
@@ -5901,6 +5907,7 @@ spec:
           - available
           - current
           - desired
+          - ignoredunresponsivenodes
           - ready
           - upToDate
           type: object

--- a/deploy/crds/datadoghq.com_extendeddaemonsetreplicasets_crd.yaml
+++ b/deploy/crds/datadoghq.com_extendeddaemonsetreplicasets_crd.yaml
@@ -19,6 +19,9 @@ spec:
   - JSONPath: .status.available
     name: available
     type: integer
+  - JSONPath: .status.ignoredunresponsivenodes
+    name: ignored unresponsive nodes
+    type: integer
   - JSONPath: .spec.selector
     name: node selector
     type: string
@@ -5894,6 +5897,9 @@ spec:
             desired:
               format: int32
               type: integer
+            ignoredunresponsivenodes:
+              format: int32
+              type: integer
             ready:
               format: int32
               type: integer
@@ -5903,6 +5909,7 @@ spec:
           - available
           - current
           - desired
+          - ignoredunresponsivenodes
           - ready
           - status
           type: object

--- a/deploy/crds/datadoghq.com_extendeddaemonsets_crd.yaml
+++ b/deploy/crds/datadoghq.com_extendeddaemonsets_crd.yaml
@@ -19,6 +19,9 @@ spec:
   - JSONPath: .status.available
     name: available
     type: integer
+  - JSONPath: .status.ignoredunresponsivenodes
+    name: ignored unresponsive nodes
+    type: integer
   - JSONPath: .status.state
     name: status
     type: string
@@ -5886,6 +5889,9 @@ spec:
             desired:
               format: int32
               type: integer
+            ignoredunresponsivenodes:
+              format: int32
+              type: integer
             ready:
               format: int32
               type: integer
@@ -5901,6 +5907,7 @@ spec:
           - available
           - current
           - desired
+          - ignoredunresponsivenodes
           - ready
           - upToDate
           type: object

--- a/pkg/apis/datadoghq/v1alpha1/extendeddaemonset_types.go
+++ b/pkg/apis/datadoghq/v1alpha1/extendeddaemonset_types.go
@@ -92,11 +92,12 @@ const (
 // ExtendedDaemonSetStatus defines the observed state of ExtendedDaemonSet
 // +k8s:openapi-gen=true
 type ExtendedDaemonSetStatus struct {
-	Desired   int32 `json:"desired"`
-	Current   int32 `json:"current"`
-	Ready     int32 `json:"ready"`
-	Available int32 `json:"available"`
-	UpToDate  int32 `json:"upToDate"`
+	Desired                  int32 `json:"desired"`
+	Current                  int32 `json:"current"`
+	Ready                    int32 `json:"ready"`
+	Available                int32 `json:"available"`
+	UpToDate                 int32 `json:"upToDate"`
+	IgnoredUnresponsiveNodes int32 `json:"ignoredunresponsivenodes"`
 
 	State            ExtendedDaemonSetStatusState   `json:"state,omitempty"`
 	ActiveReplicaSet string                         `json:"activeReplicaSet"`
@@ -121,6 +122,7 @@ type ExtendedDaemonSetStatusCanary struct {
 // +kubebuilder:printcolumn:name="ready",type="integer",JSONPath=".status.ready"
 // +kubebuilder:printcolumn:name="up-to-date",type="integer",JSONPath=".status.upToDate"
 // +kubebuilder:printcolumn:name="available",type="integer",JSONPath=".status.available"
+// +kubebuilder:printcolumn:name="ignored unresponsive nodes",type="integer",JSONPath=".status.ignoredunresponsivenodes"
 // +kubebuilder:printcolumn:name="status",type="string",JSONPath=".status.state"
 // +kubebuilder:printcolumn:name="active rs",type="string",JSONPath=".status.activeReplicaSet"
 // +kubebuilder:printcolumn:name="canary rs",type="string",JSONPath=".status.canary.replicaSet"

--- a/pkg/apis/datadoghq/v1alpha1/extendeddaemonsetreplicaset_types.go
+++ b/pkg/apis/datadoghq/v1alpha1/extendeddaemonsetreplicaset_types.go
@@ -42,11 +42,12 @@ type ExtendedDaemonSetReplicaSetSpecStrategy struct {
 // ExtendedDaemonSetReplicaSetStatus defines the observed state of ExtendedDaemonSetReplicaSet
 // +k8s:openapi-gen=true
 type ExtendedDaemonSetReplicaSetStatus struct {
-	Status    string `json:"status"`
-	Desired   int32  `json:"desired"`
-	Current   int32  `json:"current"`
-	Ready     int32  `json:"ready"`
-	Available int32  `json:"available"`
+	Status                   string `json:"status"`
+	Desired                  int32  `json:"desired"`
+	Current                  int32  `json:"current"`
+	Ready                    int32  `json:"ready"`
+	Available                int32  `json:"available"`
+	IgnoredUnresponsiveNodes int32  `json:"ignoredunresponsivenodes"`
 
 	// Conditions Represents the latest available observations of a DaemonSet's current state.
 	// +listType=set
@@ -105,6 +106,7 @@ const (
 // +kubebuilder:printcolumn:name="current",type="integer",JSONPath=".status.current"
 // +kubebuilder:printcolumn:name="ready",type="integer",JSONPath=".status.ready"
 // +kubebuilder:printcolumn:name="available",type="integer",JSONPath=".status.available"
+// +kubebuilder:printcolumn:name="ignored unresponsive nodes",type="integer",JSONPath=".status.ignoredunresponsivenodes"
 // +kubebuilder:printcolumn:name="node selector",type="string",JSONPath=".spec.selector"
 // +kubebuilder:printcolumn:name="age",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:resource:path=extendeddaemonsetreplicasets,shortName=ers

--- a/pkg/apis/datadoghq/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/datadoghq/v1alpha1/zz_generated.openapi.go
@@ -275,6 +275,12 @@ func schema_pkg_apis_datadoghq_v1alpha1_ExtendedDaemonSetReplicaSetStatus(ref co
 							Format: "int32",
 						},
 					},
+					"ignoredunresponsivenodes": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"integer"},
+							Format: "int32",
+						},
+					},
 					"conditions": {
 						VendorExtensible: spec.VendorExtensible{
 							Extensions: spec.Extensions{
@@ -294,7 +300,7 @@ func schema_pkg_apis_datadoghq_v1alpha1_ExtendedDaemonSetReplicaSetStatus(ref co
 						},
 					},
 				},
-				Required: []string{"status", "desired", "current", "ready", "available"},
+				Required: []string{"status", "desired", "current", "ready", "available", "ignoredunresponsivenodes"},
 			},
 		},
 		Dependencies: []string{
@@ -476,6 +482,12 @@ func schema_pkg_apis_datadoghq_v1alpha1_ExtendedDaemonSetStatus(ref common.Refer
 							Format: "int32",
 						},
 					},
+					"ignoredunresponsivenodes": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"integer"},
+							Format: "int32",
+						},
+					},
 					"state": {
 						SchemaProps: spec.SchemaProps{
 							Type:   []string{"string"},
@@ -494,7 +506,7 @@ func schema_pkg_apis_datadoghq_v1alpha1_ExtendedDaemonSetStatus(ref common.Refer
 						},
 					},
 				},
-				Required: []string{"desired", "current", "ready", "available", "upToDate", "activeReplicaSet"},
+				Required: []string{"desired", "current", "ready", "available", "upToDate", "ignoredunresponsivenodes", "activeReplicaSet"},
 			},
 		},
 		Dependencies: []string{

--- a/pkg/controller/extendeddaemonset/extendeddaemonset_controller.go
+++ b/pkg/controller/extendeddaemonset/extendeddaemonset_controller.go
@@ -235,6 +235,7 @@ func (r *ReconcileExtendedDaemonSet) updateStatusWithNewRS(logger logr.Logger, d
 		newDaemonset.Status.UpToDate = current.Status.Available
 		newDaemonset.Status.Available = current.Status.Available
 		newDaemonset.Status.State = datadoghqv1alpha1.ExtendedDaemonSetStatusStateRunning
+		newDaemonset.Status.IgnoredUnresponsiveNodes = current.Status.IgnoredUnresponsiveNodes
 	}
 
 	if daemonset.Spec.Strategy.Canary != nil {
@@ -250,6 +251,7 @@ func (r *ReconcileExtendedDaemonSet) updateStatusWithNewRS(logger logr.Logger, d
 			newDaemonset.Status.Desired += upToDate.Status.Desired
 			newDaemonset.Status.UpToDate += upToDate.Status.Available
 			newDaemonset.Status.Available += upToDate.Status.Available
+			newDaemonset.Status.IgnoredUnresponsiveNodes += upToDate.Status.IgnoredUnresponsiveNodes
 
 			newDaemonset.Status.Canary.ReplicaSet = upToDate.Name
 

--- a/pkg/controller/extendeddaemonsetreplicaset/ddaemonsetreplicaset_controller_test.go
+++ b/pkg/controller/extendeddaemonsetreplicaset/ddaemonsetreplicaset_controller_test.go
@@ -55,6 +55,7 @@ func TestReconcileExtendedDaemonSetReplicaSet_Reconcile(t *testing.T) {
 	}
 	daemonsetWithStatus := test.NewExtendedDaemonSet("but", "foo", &test.NewExtendedDaemonSetOptions{Labels: map[string]string{"foo-key": "bar-value"}, Status: status})
 	maxUnavailable := intstr.FromInt(1)
+	maxPodSchedulerFailure := intstr.FromInt(0)
 	slowStartAdditiveIncrease := intstr.FromInt(1)
 	slowStartIntervalDuration := metav1.Duration{Duration: time.Minute}
 	replicaset := test.NewExtendedDaemonSetReplicaSet("but", "foo-1", &test.NewExtendedDaemonSetReplicaSetOptions{
@@ -62,6 +63,7 @@ func TestReconcileExtendedDaemonSetReplicaSet_Reconcile(t *testing.T) {
 		OwnerRefName: "foo",
 		RollingUpdate: &datadoghqv1alpha1.ExtendedDaemonSetSpecStrategyRollingUpdate{
 			MaxUnavailable:            &maxUnavailable,
+			MaxPodSchedulerFailure:    &maxPodSchedulerFailure,
 			SlowStartAdditiveIncrease: &slowStartAdditiveIncrease,
 			SlowStartIntervalDuration: &slowStartIntervalDuration,
 			MaxParallelPodCreation:    datadoghqv1alpha1.NewInt32(1),


### PR DESCRIPTION
In big clusters, it can happen that some nodes are not able to run a pod
either because they are starved in a given kind of resource or because the node is unreachable.
In those situations, the ExtendedDaemonSet should not wait for the pod to eventually start on the node.
It should instead proceed as if the failed node was not there.