### PR TITLE
Add Node annotations for container resources overwrite

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,17 @@ foo-xdj4b-rgtk9   1/1     Running   0          5m31s
 foo-xdj4b-zvss2   1/1     Running   0          10m
 ```
 
+#### Overwrite container's Pod resources for a specific Node
+
+The ExtendedDaemonset controller allows to overwrite the container's pod managed by an ExtendedDaemonset for a specific Node, thanks to an annotation that you can set on the Node: `resources.extendeddaemonset.datadoghq.com/<eds-namespace>.<eds-name>.<container-name>={...}`. the value corresponds to the Resources definition in JSON.
+
+For example, for the ExtendedDaemonset named `foo` in the `bar` namespace. The container `myapp` resources specification can be overwriten by adding the following annotation on a Node:
+
+```console
+$ kubectl annotate node <node-name> `resources.extendeddaemonset.datadoghq.com/bar.foo.myapp={"requests":{"cpu":"2.0","memory":"2G"}}`
+node/<node-name> annotated
+```
+
 ### Kubectl plugin
 
 To build the the kubectl ExtendedDaemonSet plugin, you can run the command: `make build-plugin`. This will create the `kubectl-eds` Go binary, corresponding to your local OS and architecture.

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/go-logr/logr v0.1.0
 	github.com/go-openapi/spec v0.19.4
+	github.com/google/go-cmp v0.3.1
 	github.com/hako/durafmt v0.0.0-20191009132224-3f39dc1ed9f4
 	github.com/heptiolabs/healthcheck v0.0.0-20180807145615-6ff867650f40
 	github.com/olekukonko/tablewriter v0.0.2

--- a/go.sum
+++ b/go.sum
@@ -339,6 +339,7 @@ github.com/google/go-cmp v0.3.0 h1:crn/baboCvb5fXaQ0IJ1SGTsTVrWpDsCWC8EGETZijY=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.3.1 h1:Xye71clBPdm5HgqGwUkwhbynsUJZhDbS20FvLhQ2izg=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
+github.com/google/go-cmp v0.4.0 h1:xsAVV57WRhGj6kEIi8ReJzQlHHqcBYCElAvkovg3B/4=
 github.com/google/go-github v17.0.0+incompatible/go.mod h1:zLgOLi98H3fifZn+44m+umXrS52loVEgC2AApnigrVQ=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/google/gofuzz v0.0.0-20161122191042-44d81051d367/go.mod h1:HP5RmnzzSNb993RKQDq4+1A4ia9nllfqcQFTQJedwGI=

--- a/pkg/apis/datadoghq/v1alpha1/const.go
+++ b/pkg/apis/datadoghq/v1alpha1/const.go
@@ -18,5 +18,6 @@ const (
 	// should be taken into consideration during the initial rolling-update.
 	ExtendedDaemonSetOldDaemonsetAnnotationKey = "extendeddaemonset.datadoghq.com/old-daemonset"
 	// ExtendedDaemonSetRessourceNodeAnnotationKey annotation key used on Node to overwrite the resource allocated to a specific container linked to an ExtendedDaemonset
+	// The value format is: <eds-namespace>.<eds-name>.<container-name>
 	ExtendedDaemonSetRessourceNodeAnnotationKey = "resources.extendeddaemonset.datadoghq.com/%s.%s.%s"
 )

--- a/pkg/apis/datadoghq/v1alpha1/const.go
+++ b/pkg/apis/datadoghq/v1alpha1/const.go
@@ -18,5 +18,5 @@ const (
 	// should be taken into consideration during the initial rolling-update.
 	ExtendedDaemonSetOldDaemonsetAnnotationKey = "extendeddaemonset.datadoghq.com/old-daemonset"
 	// ExtendedDaemonSetRessourceNodeAnnotationKey annotation key used on Node to overwrite the resource allocated to a specific container linked to an ExtendedDaemonset
-	ExtendedDaemonSetRessourceNodeAnnotationKey = "resources.extendeddaemonset.datadoghq.com/%s.%s"
+	ExtendedDaemonSetRessourceNodeAnnotationKey = "resources.extendeddaemonset.datadoghq.com/%s.%s.%s"
 )

--- a/pkg/apis/datadoghq/v1alpha1/const.go
+++ b/pkg/apis/datadoghq/v1alpha1/const.go
@@ -17,4 +17,6 @@ const (
 	// ExtendedDaemonSetOldDaemonsetAnnotationKey annotation key used on ExtendedDaemonset in order to inform the controller that old Daemonset's pod.
 	// should be taken into consideration during the initial rolling-update.
 	ExtendedDaemonSetOldDaemonsetAnnotationKey = "extendeddaemonset.datadoghq.com/old-daemonset"
+	// ExtendedDaemonSetRessourceNodeAnnotationKey annotation key used on Node to overwrite the resource allocated to a specific container linked to an ExtendedDaemonset
+	ExtendedDaemonSetRessourceNodeAnnotationKey = "resources.extendeddaemonset.datadoghq.com/%s.%s"
 )

--- a/pkg/controller/extendeddaemonset/extendeddaemonset_controller.go
+++ b/pkg/controller/extendeddaemonset/extendeddaemonset_controller.go
@@ -284,7 +284,7 @@ func (r *ReconcileExtendedDaemonSet) updateStatusWithNewRS(logger logr.Logger, d
 
 func (r *ReconcileExtendedDaemonSet) selectNodes(logger logr.Logger, daemonsetSpec *datadoghqv1alpha1.ExtendedDaemonSetSpec, replicaset *datadoghqv1alpha1.ExtendedDaemonSetReplicaSet, canaryStatus *datadoghqv1alpha1.ExtendedDaemonSetStatusCanary) error {
 	// create a Fake pod from the current replicaset.spec.template
-	newPod := podutils.CreatePodFromDaemonSetReplicaSet(r.scheme, replicaset, "", false)
+	newPod := podutils.CreatePodFromDaemonSetReplicaSet(r.scheme, replicaset, nil, false)
 
 	nodeList := &corev1.NodeList{}
 	nodeSelector := labels.Set{}

--- a/pkg/controller/extendeddaemonset/extendeddaemonset_controller.go
+++ b/pkg/controller/extendeddaemonset/extendeddaemonset_controller.go
@@ -284,7 +284,7 @@ func (r *ReconcileExtendedDaemonSet) updateStatusWithNewRS(logger logr.Logger, d
 
 func (r *ReconcileExtendedDaemonSet) selectNodes(logger logr.Logger, daemonsetSpec *datadoghqv1alpha1.ExtendedDaemonSetSpec, replicaset *datadoghqv1alpha1.ExtendedDaemonSetReplicaSet, canaryStatus *datadoghqv1alpha1.ExtendedDaemonSetStatusCanary) error {
 	// create a Fake pod from the current replicaset.spec.template
-	newPod := podutils.CreatePodFromDaemonSetReplicaSet(r.scheme, replicaset, nil, false)
+	newPod, _ := podutils.CreatePodFromDaemonSetReplicaSet(r.scheme, replicaset, nil, false)
 
 	nodeList := &corev1.NodeList{}
 	nodeSelector := labels.Set{}

--- a/pkg/controller/extendeddaemonsetreplicaset/ddaemonsetreplicaset_controller.go
+++ b/pkg/controller/extendeddaemonsetreplicaset/ddaemonsetreplicaset_controller.go
@@ -231,7 +231,7 @@ func (r *ReconcileExtendedDaemonSetReplicaSet) buildStrategyParams(logger logr.L
 	}
 
 	// Associate Pods to Nodes
-	strategyParams.PodByNodeName, strategyParams.PodToCleanUp, strategyParams.UnscheduledPods = FilterAndMapPodsByNode(logger.WithValues("status", string(rsStatus)), replicaset, nodeList, podList, nodesFilter)
+	strategyParams.NodeByName, strategyParams.PodByNodeName, strategyParams.PodToCleanUp, strategyParams.UnscheduledPods = FilterAndMapPodsByNode(logger.WithValues("status", string(rsStatus)), replicaset, nodeList, podList, nodesFilter)
 
 	return strategyParams, nil
 }

--- a/pkg/controller/extendeddaemonsetreplicaset/filters.go
+++ b/pkg/controller/extendeddaemonsetreplicaset/filters.go
@@ -28,7 +28,7 @@ func FilterAndMapPodsByNode(logger logr.Logger, replicaset *datadoghqv1alpha1.Ex
 	}
 
 	// create a Fake pod from the current replicaset.spec.template
-	newPod := podutils.CreatePodFromDaemonSetReplicaSet(nil, replicaset, nil, false)
+	newPod, _ := podutils.CreatePodFromDaemonSetReplicaSet(nil, replicaset, nil, false)
 	// var unschedulabledNodes []*corev1.Node
 	// Associate Pods to Nodes
 	podsByNodeName := make(map[string][]*corev1.Pod)

--- a/pkg/controller/extendeddaemonsetreplicaset/scheduler/predicates.go
+++ b/pkg/controller/extendeddaemonsetreplicaset/scheduler/predicates.go
@@ -16,7 +16,7 @@ import (
 
 	"github.com/go-logr/logr"
 
-	podutils "github.com/datadog/extendeddaemonset/pkg/controller/utils/pod"
+	podaffinity "github.com/datadog/extendeddaemonset/pkg/controller/utils/affinity"
 )
 
 // CheckNodeFitness runs a set of predicates that select candidate nodes for the DaemonSet;
@@ -93,7 +93,7 @@ func chechPodToleratesNodeTaints(pod *corev1.Pod, node *corev1.Node) bool {
 // terms are ORed, and an empty list of terms will match nothing.
 func nodeMatchesNodeSelectorTerms(node *corev1.Node, nodeSelectorTerms []corev1.NodeSelectorTerm) bool {
 	nodeFields := map[string]string{
-		podutils.NodeFieldSelectorKeyNodeName: node.Name,
+		podaffinity.NodeFieldSelectorKeyNodeName: node.Name,
 	}
 	return MatchNodeSelectorTerms(nodeSelectorTerms, labels.Set(node.Labels), fields.Set(nodeFields))
 }

--- a/pkg/controller/extendeddaemonsetreplicaset/strategy/canary.go
+++ b/pkg/controller/extendeddaemonsetreplicaset/strategy/canary.go
@@ -26,17 +26,18 @@ func ManageCanaryDeployment(client client.Client, params *Parameters) (*Result, 
 	var needRequeue bool
 	// Canary mode
 	for _, nodeName := range params.CanaryNodes {
+		node := params.NodeByName[nodeName]
 		desiredPods++
-		if pod, ok := params.PodByNodeName[nodeName]; ok {
+		if pod, ok := params.PodByNodeName[node]; ok {
 			if pod == nil {
-				result.PodsToCreate = append(result.PodsToCreate, nodeName)
+				result.PodsToCreate = append(result.PodsToCreate, node)
 			} else {
 				if pod.DeletionTimestamp != nil {
 					needRequeue = true
 					continue
 				}
 				if !compareSpecTemplateMD5Hash(params.Replicaset.Spec.TemplateGeneration, pod) && pod.DeletionTimestamp == nil {
-					result.PodsToDelete = append(result.PodsToDelete, nodeName)
+					result.PodsToDelete = append(result.PodsToDelete, node)
 				} else {
 					currentPods++
 					if podUtils.IsPodAvailable(pod, 0, metaNow) {

--- a/pkg/controller/extendeddaemonsetreplicaset/strategy/type.go
+++ b/pkg/controller/extendeddaemonsetreplicaset/strategy/type.go
@@ -38,7 +38,8 @@ type Parameters struct {
 
 	CanaryNodes []string
 
-	PodByNodeName   map[string]*corev1.Pod
+	NodeByName      map[string]*corev1.Node
+	PodByNodeName   map[*corev1.Node]*corev1.Pod
 	PodToCleanUp    []*corev1.Pod
 	UnscheduledPods []*corev1.Pod
 
@@ -48,9 +49,9 @@ type Parameters struct {
 // Result information returns by a strategy
 type Result struct {
 	// PodsToCreate list of node name where Pods need to be created
-	PodsToCreate []string
+	PodsToCreate []*corev1.Node
 	// PodsToDelete list of node name where Pods need to be deleted
-	PodsToDelete []string
+	PodsToDelete []*corev1.Node
 
 	UnscheduledNodesDueToResourcesConstraints []string
 

--- a/pkg/controller/extendeddaemonsetreplicaset/strategy/unknow.go
+++ b/pkg/controller/extendeddaemonsetreplicaset/strategy/unknow.go
@@ -20,7 +20,7 @@ func ManageUnknow(client client.Client, params *Parameters) (*Result, error) {
 	result := &Result{}
 	// remove canary node if define
 	for _, nodeName := range params.CanaryNodes {
-		delete(params.PodByNodeName, nodeName)
+		delete(params.PodByNodeName, params.NodeByName[nodeName])
 	}
 	now := time.Now()
 	metaNow := metav1.NewTime(now)

--- a/pkg/controller/extendeddaemonsetreplicaset/strategy/utils.go
+++ b/pkg/controller/extendeddaemonsetreplicaset/strategy/utils.go
@@ -22,6 +22,7 @@ import (
 
 	datadoghqv1alpha1 "github.com/datadog/extendeddaemonset/pkg/apis/datadoghq/v1alpha1"
 	"github.com/datadog/extendeddaemonset/pkg/controller/extendeddaemonsetreplicaset/conditions"
+	podaffinity "github.com/datadog/extendeddaemonset/pkg/controller/utils/affinity"
 	podutils "github.com/datadog/extendeddaemonset/pkg/controller/utils/pod"
 )
 
@@ -78,7 +79,7 @@ func manageUnscheduledPodNodes(pods []*corev1.Pod) []string {
 		if condition.Status == corev1.ConditionFalse && condition.Reason == corev1.PodReasonUnschedulable {
 			nodeName := pod.Spec.NodeName
 			if nodeName == "" {
-				nodeName = podutils.GetNodeNameFromAffinity(pod.Spec.Affinity)
+				nodeName = podaffinity.GetNodeNameFromAffinity(pod.Spec.Affinity)
 			}
 			output = append(output, nodeName)
 		}

--- a/pkg/controller/test/new.go
+++ b/pkg/controller/test/new.go
@@ -8,7 +8,7 @@ package test
 import (
 	corev1 "k8s.io/api/core/v1"
 
-	utilspod "github.com/datadog/extendeddaemonset/pkg/controller/utils/pod"
+	utilaffinity "github.com/datadog/extendeddaemonset/pkg/controller/utils/affinity"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -91,6 +91,6 @@ func NewPod(namespace, name, nodeName string, opts *NewPodOptions) *corev1.Pod {
 		pod.Status.Phase = opts.Phase
 	}
 
-	utilspod.ReplaceNodeNameNodeAffinity(pod.Spec.Affinity, nodeName)
+	utilaffinity.ReplaceNodeNameNodeAffinity(pod.Spec.Affinity, nodeName)
 	return pod
 }

--- a/pkg/controller/utils/affinity/affinity.go
+++ b/pkg/controller/utils/affinity/affinity.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-2019 Datadog, Inc.
 
-package pod
+package affinity
 
 import (
 	v1 "k8s.io/api/core/v1"

--- a/pkg/controller/utils/pod/create.go
+++ b/pkg/controller/utils/pod/create.go
@@ -18,7 +18,7 @@ import (
 )
 
 // CreatePodFromDaemonSetReplicaSet use to create a Pod from a ReplicaSet instance and a specific Node name.
-func CreatePodFromDaemonSetReplicaSet(scheme *runtime.Scheme, replicaset *datadoghqv1alpha1.ExtendedDaemonSetReplicaSet, nodeName string, addNodeAffinity bool) *corev1.Pod {
+func CreatePodFromDaemonSetReplicaSet(scheme *runtime.Scheme, replicaset *datadoghqv1alpha1.ExtendedDaemonSetReplicaSet, node *corev1.Node, addNodeAffinity bool) *corev1.Pod {
 
 	templateCopy := replicaset.Spec.Template.DeepCopy()
 	{
@@ -42,11 +42,11 @@ func CreatePodFromDaemonSetReplicaSet(scheme *runtime.Scheme, replicaset *datado
 		ObjectMeta: templateCopy.ObjectMeta,
 		Spec:       templateCopy.Spec,
 	}
-	if nodeName != "" {
-		pod.Spec.NodeName = nodeName
+	if node != nil {
+		pod.Spec.NodeName = node.Name
 
 		if addNodeAffinity {
-			pod.Spec.Affinity = ReplaceNodeNameNodeAffinity(pod.Spec.Affinity, nodeName)
+			pod.Spec.Affinity = ReplaceNodeNameNodeAffinity(pod.Spec.Affinity, node.Name)
 		}
 	}
 

--- a/pkg/controller/utils/pod/create.go
+++ b/pkg/controller/utils/pod/create.go
@@ -6,20 +6,23 @@
 package pod
 
 import (
+	"encoding/json"
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
 
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/errors"
 
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	datadoghqv1alpha1 "github.com/datadog/extendeddaemonset/pkg/apis/datadoghq/v1alpha1"
+	"github.com/datadog/extendeddaemonset/pkg/controller/utils/affinity"
 )
 
 // CreatePodFromDaemonSetReplicaSet use to create a Pod from a ReplicaSet instance and a specific Node name.
-func CreatePodFromDaemonSetReplicaSet(scheme *runtime.Scheme, replicaset *datadoghqv1alpha1.ExtendedDaemonSetReplicaSet, node *corev1.Node, addNodeAffinity bool) *corev1.Pod {
-
+func CreatePodFromDaemonSetReplicaSet(scheme *runtime.Scheme, replicaset *datadoghqv1alpha1.ExtendedDaemonSetReplicaSet, node *corev1.Node, addNodeAffinity bool) (*corev1.Pod, error) {
+	var err error
 	templateCopy := replicaset.Spec.Template.DeepCopy()
 	{
 		templateCopy.ObjectMeta.Namespace = replicaset.Namespace
@@ -30,13 +33,16 @@ func CreatePodFromDaemonSetReplicaSet(scheme *runtime.Scheme, replicaset *datado
 		templateCopy.ObjectMeta.Labels = map[string]string{}
 	}
 	templateCopy.ObjectMeta.Labels[datadoghqv1alpha1.ExtendedDaemonSetReplicaSetNameLabelKey] = replicaset.Name
-	templateCopy.ObjectMeta.Labels[datadoghqv1alpha1.ExtendedDaemonSetNameLabelKey] = replicaset.Labels[datadoghqv1alpha1.ExtendedDaemonSetNameLabelKey]
+	edsName := replicaset.Labels[datadoghqv1alpha1.ExtendedDaemonSetNameLabelKey]
+	templateCopy.ObjectMeta.Labels[datadoghqv1alpha1.ExtendedDaemonSetNameLabelKey] = edsName
 
 	if templateCopy.ObjectMeta.Annotations == nil {
 		templateCopy.ObjectMeta.Annotations = map[string]string{}
 	}
 	templateCopy.ObjectMeta.Annotations[datadoghqv1alpha1.MD5ExtendedDaemonSetAnnotationKey] = replicaset.Spec.TemplateGeneration
 	templateCopy.ObjectMeta.Annotations[DaemonsetClusterAutoscalerPodAnnotationKey] = "true"
+
+	err = overwriteResourcesFromNode(templateCopy, replicaset.Namespace, edsName, node)
 
 	pod := &corev1.Pod{
 		ObjectMeta: templateCopy.ObjectMeta,
@@ -46,13 +52,34 @@ func CreatePodFromDaemonSetReplicaSet(scheme *runtime.Scheme, replicaset *datado
 		pod.Spec.NodeName = node.Name
 
 		if addNodeAffinity {
-			pod.Spec.Affinity = ReplaceNodeNameNodeAffinity(pod.Spec.Affinity, node.Name)
+			pod.Spec.Affinity = affinity.ReplaceNodeNameNodeAffinity(pod.Spec.Affinity, node.Name)
 		}
 	}
 
 	if scheme != nil {
-		_ = controllerutil.SetControllerReference(replicaset, pod, scheme)
+		err = controllerutil.SetControllerReference(replicaset, pod, scheme)
 	}
 
-	return pod
+	return pod, err
+}
+
+func overwriteResourcesFromNode(template *corev1.PodTemplateSpec, edsNamespace, edsName string, node *corev1.Node) error {
+	if node == nil {
+		return nil
+	}
+
+	var errs []error
+	for id, container := range template.Spec.Containers {
+		ressourceAnnotationKey := fmt.Sprintf(datadoghqv1alpha1.ExtendedDaemonSetRessourceNodeAnnotationKey, edsNamespace, edsName, container.Name)
+		if val, ok := node.GetAnnotations()[ressourceAnnotationKey]; ok {
+			var newResources corev1.ResourceRequirements
+			if err := json.Unmarshal([]byte(val), &newResources); err != nil {
+				errWrap := fmt.Errorf("unable to decode %s annotation value, err: %v", ressourceAnnotationKey, err)
+				errs = append(errs, errWrap)
+				continue
+			}
+			template.Spec.Containers[id].Resources = newResources
+		}
+	}
+	return errors.NewAggregate(errs)
 }

--- a/pkg/controller/utils/pod/create_test.go
+++ b/pkg/controller/utils/pod/create_test.go
@@ -1,0 +1,129 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2019 Datadog, Inc.
+
+package pod
+
+import (
+	"fmt"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+
+	datadoghqv1alpha1 "github.com/datadog/extendeddaemonset/pkg/apis/datadoghq/v1alpha1"
+	ctrltest "github.com/datadog/extendeddaemonset/pkg/controller/test"
+	"github.com/google/go-cmp/cmp"
+)
+
+func Test_overwriteResourcesFromNode(t *testing.T) {
+	type args struct {
+		template     *corev1.PodTemplateSpec
+		edsNamespace string
+		edsName      string
+		node         *corev1.Node
+	}
+	tests := []struct {
+		name         string
+		args         args
+		wantErr      bool
+		wantTemplate *corev1.PodTemplateSpec
+	}{
+		{
+			name: "nil node",
+			args: args{
+				template: &corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{Name: "container1"},
+						},
+					},
+				},
+				edsNamespace: "bar",
+				edsName:      "foo",
+			},
+			wantErr: false,
+		},
+		{
+			name: "no annotation",
+			args: args{
+				template: &corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{Name: "container1"},
+						},
+					},
+				},
+				edsNamespace: "bar",
+				edsName:      "foo",
+				node:         ctrltest.NewNode("node1", nil),
+			},
+			wantErr: false,
+		},
+		{
+			name: "annotation requests.cpu",
+			args: args{
+				template: &corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{Name: "container1"},
+						},
+					},
+				},
+				edsNamespace: "bar",
+				edsName:      "foo",
+				node: ctrltest.NewNode("node1", &ctrltest.NewNodeOptions{
+					Annotations: map[string]string{
+						fmt.Sprintf(datadoghqv1alpha1.ExtendedDaemonSetRessourceNodeAnnotationKey, "bar", "foo", "container1"): `{"Requests": {"cpu": "1.5"}}`,
+					}}),
+			},
+			wantErr: false,
+			wantTemplate: &corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "container1",
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU: resource.MustParse("1.5"),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "annotation requests.cpu",
+			args: args{
+				template: &corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{Name: "container1"},
+						},
+					},
+				},
+				edsNamespace: "bar",
+				edsName:      "foo",
+				node: ctrltest.NewNode("node1", &ctrltest.NewNodeOptions{
+					Annotations: map[string]string{
+						fmt.Sprintf(datadoghqv1alpha1.ExtendedDaemonSetRessourceNodeAnnotationKey, "bar", "foo", "container1"): `{"Requests": invalid {"cpu": "1.5"}}`,
+					}}),
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := overwriteResourcesFromNode(tt.args.template, tt.args.edsNamespace, tt.args.edsName, tt.args.node); (err != nil) != tt.wantErr {
+				t.Errorf("overwriteResourcesFromNode() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantTemplate != nil {
+				if diff := cmp.Diff(tt.wantTemplate, tt.args.template); diff != "" {
+					t.Errorf("template mismatch (-want +got):\n%s", diff)
+				}
+			}
+		})
+	}
+}

--- a/pkg/controller/utils/pod/pod.go
+++ b/pkg/controller/utils/pod/pod.go
@@ -27,6 +27,8 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/datadog/extendeddaemonset/pkg/controller/utils/affinity"
 )
 
 // GetContainerStatus extracts the status of container "name" from "statuses".
@@ -50,7 +52,7 @@ func GetExistingContainerStatus(statuses []v1.ContainerStatus, name string) v1.C
 // IsPodScheduled return true if it is already assigned to a Node
 func IsPodScheduled(pod *v1.Pod) (string, bool) {
 	isScheduled := pod.Spec.NodeName != ""
-	nodeName := GetNodeNameFromAffinity(pod.Spec.Affinity)
+	nodeName := affinity.GetNodeNameFromAffinity(pod.Spec.Affinity)
 	return nodeName, isScheduled
 }
 


### PR DESCRIPTION
Add the possibility to overwrites de container's pod managed by an ExtendedDaemonset for a specific Node, thanks to an annotation that you can set on the Node: `resources.extendeddaemonset.datadoghq.com/<eds-namespace>.<eds-name>.<container-name>={...}`. the value corresponds to the Resources definition in JSON.

an example:
```console
$ kubectl annotate node <node-name> `resources.extendeddaemonset.datadoghq.com/bar.foo.myapp={"requests":{"cpu":"2.0","memory":"2G"}}`
node/<node-name> annotated
```