### PR TITLE
Avoid adding new annotation if not needed

### DIFF
--- a/pkg/controller/extendeddaemonsetreplicaset/strategy/utils.go
+++ b/pkg/controller/extendeddaemonsetreplicaset/strategy/utils.go
@@ -44,7 +44,7 @@ func compareCurrentPodWithNewPod(params *Parameters, pod *corev1.Pod, node *Node
 
 func compareNodeResourcesOverwriteMD5Hash(edsName string, replicaset *datadoghqv1alpha1.ExtendedDaemonSetReplicaSet, pod *corev1.Pod, node *NodeItem) bool {
 	nodeHash := comparison.GenerateHashFromEDSResourceNodeAnnotation(replicaset.Namespace, edsName, node.Node.GetAnnotations())
-	if val, ok := pod.Annotations[datadoghqv1alpha1.MD5NodeExtendedDaemonSetAnnotationKey]; ok && val == nodeHash {
+	if val, ok := pod.Annotations[datadoghqv1alpha1.MD5NodeExtendedDaemonSetAnnotationKey]; nodeHash == "" || ok && val == nodeHash {
 		return true
 	}
 	return false

--- a/pkg/controller/extendeddaemonsetreplicaset/strategy/utils.go
+++ b/pkg/controller/extendeddaemonsetreplicaset/strategy/utils.go
@@ -44,7 +44,7 @@ func compareCurrentPodWithNewPod(params *Parameters, pod *corev1.Pod, node *Node
 
 func compareNodeResourcesOverwriteMD5Hash(edsName string, replicaset *datadoghqv1alpha1.ExtendedDaemonSetReplicaSet, pod *corev1.Pod, node *NodeItem) bool {
 	nodeHash := comparison.GenerateHashFromEDSResourceNodeAnnotation(replicaset.Namespace, edsName, node.Node.GetAnnotations())
-	if val, ok := pod.Annotations[datadoghqv1alpha1.MD5NodeExtendedDaemonSetAnnotationKey]; nodeHash == "" || ok && val == nodeHash {
+	if val, ok := pod.Annotations[datadoghqv1alpha1.MD5NodeExtendedDaemonSetAnnotationKey]; !ok && nodeHash == "" || ok && val == nodeHash {
 		return true
 	}
 	return false

--- a/pkg/controller/utils/pod/create.go
+++ b/pkg/controller/utils/pod/create.go
@@ -47,7 +47,10 @@ func CreatePodFromDaemonSetReplicaSet(scheme *runtime.Scheme, replicaset *datado
 
 	if node != nil {
 		err = overwriteResourcesFromNode(templateCopy, replicaset.Namespace, edsName, node)
-		templateCopy.ObjectMeta.Annotations[datadoghqv1alpha1.MD5NodeExtendedDaemonSetAnnotationKey] = comparison.GenerateHashFromEDSResourceNodeAnnotation(replicaset.Namespace, edsName, node.Annotations)
+		hash := comparison.GenerateHashFromEDSResourceNodeAnnotation(replicaset.Namespace, edsName, node.Annotations)
+		if hash != "" {
+			templateCopy.ObjectMeta.Annotations[datadoghqv1alpha1.MD5NodeExtendedDaemonSetAnnotationKey] = hash
+		}
 	}
 
 	pod := &corev1.Pod{


### PR DESCRIPTION
avoid adding "MD5NodeExtendedDaemonSetAnnotationKey" annotation if the value is empty