### PR TITLE
fix EDS and ERS status

### DIFF
--- a/pkg/controller/extendeddaemonsetreplicaset/strategy/unknow.go
+++ b/pkg/controller/extendeddaemonsetreplicaset/strategy/unknow.go
@@ -34,13 +34,13 @@ func ManageUnknow(client client.Client, params *Parameters) (*Result, error) {
 
 	for node, pod := range params.PodByNodeName {
 		desiredPods++
-		if pod == nil {
-		} else {
-			if podutils.HasPodSchedulerIssue(pod) && int(nbIgnoredUnresponsiveNodes) < maxPodSchedulerFailure {
-				nbIgnoredUnresponsiveNodes++
-				continue
-			}
-			if !compareCurrentPodWithNewPod(params, pod, node) {
+		if pod != nil {
+			if compareCurrentPodWithNewPod(params, pod, node) {
+				if podutils.HasPodSchedulerIssue(pod) && int(nbIgnoredUnresponsiveNodes) < maxPodSchedulerFailure {
+					nbIgnoredUnresponsiveNodes++
+					continue
+				}
+
 				currentPods++
 				if podutils.IsPodAvailable(pod, 0, metaNow) {
 					availablePods++


### PR DESCRIPTION
Fix a bug in the Replicaset status introduce by this [commit](https://github.com/DataDog/extendeddaemonset/commit/425c3b464b9d28a7aaacbc0eaf5dd1d517e85093#diff-b2d10549e071d7b0fdcce4253d400930L43)

The bug was responsible to set in the ReplicaSet status when it is not the active "replicaset" the wrong value.