### PR TITLE
Enable the possiblity to pause a Canary deployment

### DIFF
--- a/deploy/crds/datadoghq.com_extendeddaemonsets_crd.yaml
+++ b/deploy/crds/datadoghq.com_extendeddaemonsets_crd.yaml
@@ -117,11 +117,15 @@ spec:
                   properties:
                     duration:
                       type: string
+                    paused:
+                      type: boolean
                     replicas:
                       anyOf:
                       - type: integer
                       - type: string
                       x-kubernetes-int-or-string: true
+                  required:
+                  - paused
                   type: object
                 reconcileFrequency:
                   description: ReconcileFrequency use to configure how often the ExtendedDeamonset

--- a/deploy/crds/datadoghq.com_extendeddaemonsets_crd.yaml
+++ b/deploy/crds/datadoghq.com_extendeddaemonsets_crd.yaml
@@ -31,6 +31,9 @@ spec:
   - JSONPath: .status.canary.replicaSet
     name: canary rs
     type: string
+  - JSONPath: .spec.strategy.canary.paused
+    name: canary paused
+    type: boolean
   - JSONPath: .metadata.creationTimestamp
     name: age
     type: date
@@ -124,8 +127,6 @@ spec:
                       - type: integer
                       - type: string
                       x-kubernetes-int-or-string: true
-                  required:
-                  - paused
                   type: object
                 reconcileFrequency:
                   description: ReconcileFrequency use to configure how often the ExtendedDeamonset

--- a/pkg/apis/datadoghq/v1alpha1/extendeddaemonset_types.go
+++ b/pkg/apis/datadoghq/v1alpha1/extendeddaemonset_types.go
@@ -75,6 +75,7 @@ type ExtendedDaemonSetSpecStrategyRollingUpdate struct {
 type ExtendedDaemonSetSpecStrategyCanary struct {
 	Replicas *intstr.IntOrString `json:"replicas,omitempty"`
 	Duration *metav1.Duration    `json:"duration,omitempty"`
+	Paused   bool                `json:"paused"`
 }
 
 // ExtendedDaemonSetStatusState type representing the ExtendedDaemonSet state

--- a/pkg/apis/datadoghq/v1alpha1/extendeddaemonset_types.go
+++ b/pkg/apis/datadoghq/v1alpha1/extendeddaemonset_types.go
@@ -75,7 +75,8 @@ type ExtendedDaemonSetSpecStrategyRollingUpdate struct {
 type ExtendedDaemonSetSpecStrategyCanary struct {
 	Replicas *intstr.IntOrString `json:"replicas,omitempty"`
 	Duration *metav1.Duration    `json:"duration,omitempty"`
-	Paused   bool                `json:"paused"`
+	// +optional
+	Paused bool `json:"paused,omitempty"`
 }
 
 // ExtendedDaemonSetStatusState type representing the ExtendedDaemonSet state
@@ -128,6 +129,7 @@ type ExtendedDaemonSetStatusCanary struct {
 // +kubebuilder:printcolumn:name="status",type="string",JSONPath=".status.state"
 // +kubebuilder:printcolumn:name="active rs",type="string",JSONPath=".status.activeReplicaSet"
 // +kubebuilder:printcolumn:name="canary rs",type="string",JSONPath=".status.canary.replicaSet"
+// +kubebuilder:printcolumn:name="canary paused",type="boolean",JSONPath=".spec.strategy.canary.paused"
 // +kubebuilder:printcolumn:name="age",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:resource:path=extendeddaemonsets,shortName=eds
 type ExtendedDaemonSet struct {

--- a/pkg/apis/datadoghq/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/datadoghq/v1alpha1/zz_generated.openapi.go
@@ -397,7 +397,6 @@ func schema_pkg_apis_datadoghq_v1alpha1_ExtendedDaemonSetSpecStrategyCanary(ref 
 						},
 					},
 				},
-				Required: []string{"paused"},
 			},
 		},
 		Dependencies: []string{

--- a/pkg/apis/datadoghq/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/datadoghq/v1alpha1/zz_generated.openapi.go
@@ -390,7 +390,14 @@ func schema_pkg_apis_datadoghq_v1alpha1_ExtendedDaemonSetSpecStrategyCanary(ref 
 							Ref: ref("k8s.io/apimachinery/pkg/apis/meta/v1.Duration"),
 						},
 					},
+					"paused": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"boolean"},
+							Format: "",
+						},
+					},
 				},
+				Required: []string{"paused"},
 			},
 		},
 		Dependencies: []string{

--- a/pkg/controller/extendeddaemonset/utils.go
+++ b/pkg/controller/extendeddaemonset/utils.go
@@ -26,7 +26,7 @@ func IsCanaryPhaseEnded(specCanary *datadoghqv1alpha1.ExtendedDaemonSetSpecStrat
 	if specCanary == nil {
 		return true, pendingDuration
 	}
-	if specCanary.Duration == nil {
+	if specCanary.Paused || specCanary.Duration == nil {
 		// in this case, it means the canary never ends
 		return false, pendingDuration
 	}

--- a/pkg/controller/extendeddaemonset/utils_test.go
+++ b/pkg/controller/extendeddaemonset/utils_test.go
@@ -65,6 +65,22 @@ func TestIsCanaryPhaseEnded(t *testing.T) {
 			want: false,
 		},
 		{
+			name: "canary paused duration exceeded",
+			args: args{
+				specCanary: &datadoghqv1alpha1.ExtendedDaemonSetSpecStrategyCanary{
+					Duration: &metav1.Duration{Duration: time.Hour},
+					Paused:   true,
+				},
+				rs: &datadoghqv1alpha1.ExtendedDaemonSetReplicaSet{
+					ObjectMeta: metav1.ObjectMeta{
+						CreationTimestamp: metav1.NewTime(now.Add(-2 * time.Hour)),
+					},
+				},
+				now: now,
+			},
+			want: false,
+		},
+		{
 			name: "not canary done",
 			args: args{
 				specCanary: &datadoghqv1alpha1.ExtendedDaemonSetSpecStrategyCanary{

--- a/pkg/plugin/canary.go
+++ b/pkg/plugin/canary.go
@@ -1,0 +1,20 @@
+package plugin
+
+import (
+	"github.com/spf13/cobra"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+)
+
+// NewCmdCanary provides a cobra command to control canary deployments.
+func NewCmdCanary(streams genericclioptions.IOStreams) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "canary [subcommand] [flags]",
+		Short: "control ExtendedDaemonset canary deployment",
+	}
+
+	cmd.AddCommand(NewCmdValidate(streams))
+	cmd.AddCommand(NewCmdPause(streams))
+	cmd.AddCommand(NewCmdUnpause(streams))
+
+	return cmd
+}

--- a/pkg/plugin/common.go
+++ b/pkg/plugin/common.go
@@ -26,6 +26,13 @@ func getCanaryRS(eds *v1alpha1.ExtendedDaemonSet) string {
 	return "-"
 }
 
+func getCanaryPaused(eds *v1alpha1.ExtendedDaemonSet) string {
+	if eds.Spec.Strategy.Canary != nil {
+		return fmt.Sprintf("%t", eds.Spec.Strategy.Canary.Paused)
+	}
+	return "-"
+}
+
 func getDuration(obj *metav1.ObjectMeta) string {
 	return durafmt.ParseShort(time.Since(obj.CreationTimestamp.Time)).String()
 }

--- a/pkg/plugin/extendeddaemonset.go
+++ b/pkg/plugin/extendeddaemonset.go
@@ -34,7 +34,7 @@ func NewCmdExtendedDaemonset(streams genericclioptions.IOStreams) *cobra.Command
 		Use: "ExtendedDaemonset [subcommand] [flags]",
 	}
 
-	cmd.AddCommand(NewCmdValidate(streams))
+	cmd.AddCommand(NewCmdCanary(streams))
 	cmd.AddCommand(NewCmdGet(streams))
 	cmd.AddCommand(NewCmdGetERS(streams))
 

--- a/pkg/plugin/get.go
+++ b/pkg/plugin/get.go
@@ -143,7 +143,7 @@ func (o *GetOptions) Run() error {
 
 	table := newGetTable(o.Out)
 	for _, item := range edsList.Items {
-		data := []string{item.Namespace, item.Name, intToString(item.Status.Desired), intToString(item.Status.Current), intToString(item.Status.Ready), intToString(item.Status.UpToDate), intToString(item.Status.Available), intToString(item.Status.IgnoredUnresponsiveNodes), string(item.Status.State), item.Status.ActiveReplicaSet, getCanaryRS(&item), getDuration(&item.ObjectMeta)}
+		data := []string{item.Namespace, item.Name, intToString(item.Status.Desired), intToString(item.Status.Current), intToString(item.Status.Ready), intToString(item.Status.UpToDate), intToString(item.Status.Available), intToString(item.Status.IgnoredUnresponsiveNodes), string(item.Status.State), item.Status.ActiveReplicaSet, getCanaryRS(&item), getCanaryPaused(&item), getDuration(&item.ObjectMeta)}
 		table.Append(data)
 	}
 
@@ -154,7 +154,7 @@ func (o *GetOptions) Run() error {
 
 func newGetTable(out io.Writer) *tablewriter.Table {
 	table := tablewriter.NewWriter(out)
-	table.SetHeader([]string{"Namespace", "Name", "Desired", "Current", "Ready", "Up-to-date", "Available", "Ignored Unresponsive Nodes", "Status", "Active RS", "Canary RS", "Age"})
+	table.SetHeader([]string{"Namespace", "Name", "Desired", "Current", "Ready", "Up-to-date", "Available", "Ignored Unresponsive Nodes", "Status", "Active RS", "Canary RS", "Canary Paused", "Age"})
 	table.SetBorders(tablewriter.Border{Left: false, Top: false, Right: false, Bottom: false})
 	table.SetHeaderAlignment(tablewriter.ALIGN_LEFT)
 	table.SetRowLine(false)

--- a/pkg/plugin/pause.go
+++ b/pkg/plugin/pause.go
@@ -1,0 +1,147 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2019 Datadog, Inc.
+
+package plugin
+
+import (
+	"context"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+
+	"github.com/spf13/cobra"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+
+	"github.com/datadog/extendeddaemonset/pkg/apis/datadoghq/v1alpha1"
+)
+
+var (
+	pauseExample = `
+	# pause a canary replicaset
+	%[1]s pause foo
+`
+)
+
+// PauseOptions provides information required to manage ExtendedDaemonSet
+type PauseOptions struct {
+	configFlags *genericclioptions.ConfigFlags
+	args        []string
+
+	client client.Client
+
+	genericclioptions.IOStreams
+
+	userNamespace             string
+	userExtendedDaemonSetName string
+}
+
+// NewPauseOptions provides an instance of GetOptions with default values
+func NewPauseOptions(streams genericclioptions.IOStreams) *PauseOptions {
+	return &PauseOptions{
+		configFlags: genericclioptions.NewConfigFlags(false),
+
+		IOStreams: streams,
+	}
+}
+
+// NewCmdPause provides a cobra command wrapping PauseOptions
+func NewCmdPause(streams genericclioptions.IOStreams) *cobra.Command {
+	o := NewPauseOptions(streams)
+
+	cmd := &cobra.Command{
+		Use:          "pause an ExtendedDaemonSet canary replicaset",
+		Short:        "pause canary replicaset",
+		Example:      fmt.Sprintf(pauseExample, "kubectl"),
+		SilenceUsage: true,
+		RunE: func(c *cobra.Command, args []string) error {
+			if err := o.Complete(c, args); err != nil {
+				return err
+			}
+			if err := o.Validate(); err != nil {
+				return err
+			}
+			return o.Run()
+		},
+	}
+
+	o.configFlags.AddFlags(cmd.Flags())
+
+	return cmd
+}
+
+// Complete sets all information required for processing the command
+func (o *PauseOptions) Complete(cmd *cobra.Command, args []string) error {
+	o.args = args
+	var err error
+
+	clientConfig := o.configFlags.ToRawKubeConfigLoader()
+	// Create the Client for Read/Write operations.
+	o.client, err = NewClient(clientConfig)
+	if err != nil {
+		return fmt.Errorf("unable to instantiate client, err: %v", err)
+	}
+
+	o.userNamespace, _, err = clientConfig.Namespace()
+	if err != nil {
+		return err
+	}
+
+	ns, err2 := cmd.Flags().GetString("namespace")
+	if err2 != nil {
+		return err
+	}
+	if ns != "" {
+		o.userNamespace = ns
+	}
+
+	if len(args) > 0 {
+		o.userExtendedDaemonSetName = args[0]
+	}
+
+	return nil
+}
+
+// Validate ensures that all required arguments and flag values are provided
+func (o *PauseOptions) Validate() error {
+
+	if len(o.args) < 1 {
+		return fmt.Errorf("the extendeddaemonset name is required")
+	}
+
+	return nil
+}
+
+// Run use to run the command
+func (o *PauseOptions) Run() error {
+	eds := &v1alpha1.ExtendedDaemonSet{}
+	err := o.client.Get(context.TODO(), client.ObjectKey{Namespace: o.userNamespace, Name: o.userExtendedDaemonSetName}, eds)
+	if err != nil && errors.IsNotFound(err) {
+		return fmt.Errorf("ExtendedDaemonSet %s/%s not found", o.userNamespace, o.userExtendedDaemonSetName)
+	} else if err != nil {
+		return fmt.Errorf("unable to get ExtendedDaemonSet, err: %v", err)
+	}
+
+	if eds.Spec.Strategy.Canary == nil {
+		return fmt.Errorf("the ExtendedDaemonset does not have a canary")
+	}
+
+	if eds.Spec.Strategy.Canary.Paused {
+		return fmt.Errorf("ExtendedDaemonset '%s/%s' deployment already paused", o.userNamespace, o.userExtendedDaemonSetName)
+	}
+
+	newEds := eds.DeepCopy()
+	newEds.Spec.Strategy.Canary.Paused = true
+
+	if err = o.client.Update(context.TODO(), newEds); err != nil {
+		return fmt.Errorf("unable to pause ExtendedDaemonset deployment, err: %v", err)
+	}
+
+	fmt.Fprintf(o.Out, "ExtendedDaemonset '%s/%s' deployment was paused\n", o.userNamespace, o.userExtendedDaemonSetName)
+
+	return nil
+}


### PR DESCRIPTION
In the ExtendedDaemonset.Spec.Strategy, it is possible to define a
duration for the Canary deployment. At the end of this duration, if the
ExtendedDaemonset was not rolled back, the Canary deployment becomes
active and the rolling-update continues on all the nodes. By adding a
Paused field, it's now possible to prevent that from happening until
Paused is set back to false again. That's useful to investigate faulty
deployments as they currently are, without the need for a full rollback.

Another way we could've implemented this would be with an annotation,
but the last thing one needs when trying to prevent disaster is
misspelling an annotation that's not validated, so I preferred to go
with a new field.