### PR TITLE
Add some facilities to tune the selection of canary nodes

### DIFF
--- a/deploy/crds/datadoghq.com_extendeddaemonsets_crd.yaml
+++ b/deploy/crds/datadoghq.com_extendeddaemonsets_crd.yaml
@@ -117,6 +117,10 @@ spec:
                   properties:
                     duration:
                       type: string
+                    nodeAntiAffinityKeys:
+                      items:
+                        type: string
+                      type: array
                     nodeSelector:
                       description: A label selector is a label query over a set of
                         resources. The result of matchLabels and matchExpressions

--- a/deploy/crds/datadoghq.com_extendeddaemonsets_crd.yaml
+++ b/deploy/crds/datadoghq.com_extendeddaemonsets_crd.yaml
@@ -117,6 +117,53 @@ spec:
                   properties:
                     duration:
                       type: string
+                    nodeSelector:
+                      description: A label selector is a label query over a set of
+                        resources. The result of matchLabels and matchExpressions
+                        are ANDed. An empty label selector matches all objects. A
+                        null label selector matches no objects.
+                      properties:
+                        matchExpressions:
+                          description: matchExpressions is a list of label selector
+                            requirements. The requirements are ANDed.
+                          items:
+                            description: A label selector requirement is a selector
+                              that contains values, a key, and an operator that relates
+                              the key and values.
+                            properties:
+                              key:
+                                description: key is the label key that the selector
+                                  applies to.
+                                type: string
+                              operator:
+                                description: operator represents a key's relationship
+                                  to a set of values. Valid operators are In, NotIn,
+                                  Exists and DoesNotExist.
+                                type: string
+                              values:
+                                description: values is an array of string values.
+                                  If the operator is In or NotIn, the values array
+                                  must be non-empty. If the operator is Exists or
+                                  DoesNotExist, the values array must be empty. This
+                                  array is replaced during a strategic merge patch.
+                                items:
+                                  type: string
+                                type: array
+                            required:
+                            - key
+                            - operator
+                            type: object
+                          type: array
+                        matchLabels:
+                          additionalProperties:
+                            type: string
+                          description: matchLabels is a map of {key,value} pairs.
+                            A single {key,value} in the matchLabels map is equivalent
+                            to an element of matchExpressions, whose key field is
+                            "key", the operator is "In", and the values array contains
+                            only "value". The requirements are ANDed.
+                          type: object
+                      type: object
                     replicas:
                       anyOf:
                       - type: integer

--- a/pkg/apis/datadoghq/v1alpha1/extendeddaemonset_default.go
+++ b/pkg/apis/datadoghq/v1alpha1/extendeddaemonset_default.go
@@ -82,6 +82,9 @@ func IsDefaultedExtendedDaemonSetSpecStrategyCanary(canary *ExtendedDaemonSetSpe
 	if canary.Duration == nil {
 		return false
 	}
+	if canary.NodeSelector == nil {
+		return false
+	}
 	return true
 }
 
@@ -121,6 +124,11 @@ func DefaultExtendedDaemonSetSpecStrategyCanary(c *ExtendedDaemonSetSpecStrategy
 	if c.Replicas == nil {
 		replicas := intstr.FromInt(defaultCanaryReplica)
 		c.Replicas = &replicas
+	}
+	if c.NodeSelector == nil {
+		c.NodeSelector = &metav1.LabelSelector{
+			MatchLabels: map[string]string{},
+		}
 	}
 	return c
 }

--- a/pkg/apis/datadoghq/v1alpha1/extendeddaemonset_types.go
+++ b/pkg/apis/datadoghq/v1alpha1/extendeddaemonset_types.go
@@ -73,9 +73,10 @@ type ExtendedDaemonSetSpecStrategyRollingUpdate struct {
 // ExtendedDaemonSetSpecStrategyCanary defines the canary deployment strategy of ExtendedDaemonSet
 // +k8s:openapi-gen=true
 type ExtendedDaemonSetSpecStrategyCanary struct {
-	Replicas     *intstr.IntOrString   `json:"replicas,omitempty"`
-	Duration     *metav1.Duration      `json:"duration,omitempty"`
-	NodeSelector *metav1.LabelSelector `json:"nodeSelector,omitempty"`
+	Replicas             *intstr.IntOrString   `json:"replicas,omitempty"`
+	Duration             *metav1.Duration      `json:"duration,omitempty"`
+	NodeSelector         *metav1.LabelSelector `json:"nodeSelector,omitempty"`
+	NodeAntiAffinityKeys []string              `json:"nodeAntiAffinityKeys,omitempty"`
 }
 
 // ExtendedDaemonSetStatusState type representing the ExtendedDaemonSet state

--- a/pkg/apis/datadoghq/v1alpha1/extendeddaemonset_types.go
+++ b/pkg/apis/datadoghq/v1alpha1/extendeddaemonset_types.go
@@ -73,8 +73,9 @@ type ExtendedDaemonSetSpecStrategyRollingUpdate struct {
 // ExtendedDaemonSetSpecStrategyCanary defines the canary deployment strategy of ExtendedDaemonSet
 // +k8s:openapi-gen=true
 type ExtendedDaemonSetSpecStrategyCanary struct {
-	Replicas *intstr.IntOrString `json:"replicas,omitempty"`
-	Duration *metav1.Duration    `json:"duration,omitempty"`
+	Replicas     *intstr.IntOrString   `json:"replicas,omitempty"`
+	Duration     *metav1.Duration      `json:"duration,omitempty"`
+	NodeSelector *metav1.LabelSelector `json:"nodeSelector,omitempty"`
 }
 
 // ExtendedDaemonSetStatusState type representing the ExtendedDaemonSet state

--- a/pkg/apis/datadoghq/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/datadoghq/v1alpha1/zz_generated.deepcopy.go
@@ -282,6 +282,11 @@ func (in *ExtendedDaemonSetSpecStrategyCanary) DeepCopyInto(out *ExtendedDaemonS
 		*out = new(v1.Duration)
 		**out = **in
 	}
+	if in.NodeSelector != nil {
+		in, out := &in.NodeSelector, &out.NodeSelector
+		*out = new(v1.LabelSelector)
+		(*in).DeepCopyInto(*out)
+	}
 	return
 }
 

--- a/pkg/apis/datadoghq/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/datadoghq/v1alpha1/zz_generated.deepcopy.go
@@ -287,6 +287,11 @@ func (in *ExtendedDaemonSetSpecStrategyCanary) DeepCopyInto(out *ExtendedDaemonS
 		*out = new(v1.LabelSelector)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.NodeAntiAffinityKeys != nil {
+		in, out := &in.NodeAntiAffinityKeys, &out.NodeAntiAffinityKeys
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/pkg/apis/datadoghq/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/datadoghq/v1alpha1/zz_generated.openapi.go
@@ -390,11 +390,16 @@ func schema_pkg_apis_datadoghq_v1alpha1_ExtendedDaemonSetSpecStrategyCanary(ref 
 							Ref: ref("k8s.io/apimachinery/pkg/apis/meta/v1.Duration"),
 						},
 					},
+					"nodeSelector": {
+						SchemaProps: spec.SchemaProps{
+							Ref: ref("k8s.io/apimachinery/pkg/apis/meta/v1.LabelSelector"),
+						},
+					},
 				},
 			},
 		},
 		Dependencies: []string{
-			"k8s.io/apimachinery/pkg/apis/meta/v1.Duration", "k8s.io/apimachinery/pkg/util/intstr.IntOrString"},
+			"k8s.io/apimachinery/pkg/apis/meta/v1.Duration", "k8s.io/apimachinery/pkg/apis/meta/v1.LabelSelector", "k8s.io/apimachinery/pkg/util/intstr.IntOrString"},
 	}
 }
 

--- a/pkg/apis/datadoghq/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/datadoghq/v1alpha1/zz_generated.openapi.go
@@ -395,6 +395,19 @@ func schema_pkg_apis_datadoghq_v1alpha1_ExtendedDaemonSetSpecStrategyCanary(ref 
 							Ref: ref("k8s.io/apimachinery/pkg/apis/meta/v1.LabelSelector"),
 						},
 					},
+					"nodeAntiAffinityKeys": {
+						SchemaProps: spec.SchemaProps{
+							Type: []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Type:   []string{"string"},
+										Format: "",
+									},
+								},
+							},
+						},
+					},
 				},
 			},
 		},

--- a/pkg/controller/extendeddaemonset/extendeddaemonset_controller.go
+++ b/pkg/controller/extendeddaemonset/extendeddaemonset_controller.go
@@ -294,6 +294,14 @@ func (r *ReconcileExtendedDaemonSet) selectNodes(logger logr.Logger, daemonsetSp
 	listOptions := []client.ListOption{
 		&client.MatchingLabelsSelector{Selector: nodeSelector.AsSelectorPreValidated()},
 	}
+	if daemonsetSpec.Strategy.Canary != nil && daemonsetSpec.Strategy.Canary.NodeSelector != nil {
+		canaryNodeSelector := labels.Set(daemonsetSpec.Strategy.Canary.NodeSelector.MatchLabels)
+		listOptions = append(listOptions,
+			&client.MatchingLabelsSelector{
+				Selector: canaryNodeSelector.AsSelectorPreValidated(),
+			},
+		)
+	}
 	err := r.client.List(context.TODO(), nodeList, listOptions...)
 	if err != nil {
 		return err

--- a/pkg/controller/extendeddaemonset/extendeddaemonset_controller_test.go
+++ b/pkg/controller/extendeddaemonset/extendeddaemonset_controller_test.go
@@ -53,6 +53,10 @@ func TestReconcileExtendedDaemonSet_selectNodes(t *testing.T) {
 	node3 := commontest.NewNode("node3", nodeOptions)
 	intString3 := intstr.FromInt(3)
 
+	node2.Labels = map[string]string{
+		"canary": "true",
+	}
+
 	options1 := &test.NewExtendedDaemonSetOptions{
 		Canary: &datadoghqv1alpha1.ExtendedDaemonSetSpecStrategyCanary{
 			Replicas: &intString3,
@@ -67,6 +71,27 @@ func TestReconcileExtendedDaemonSet_selectNodes(t *testing.T) {
 	}
 	extendeddaemonset1 := test.NewExtendedDaemonSet("bar", "foo", options1)
 
+	intString1 := intstr.FromInt(1)
+
+	options2 := &test.NewExtendedDaemonSetOptions{
+		Canary: &datadoghqv1alpha1.ExtendedDaemonSetSpecStrategyCanary{
+			Replicas: &intString1,
+			NodeSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"canary": "true",
+				},
+			},
+		},
+		Status: &datadoghqv1alpha1.ExtendedDaemonSetStatus{
+			ActiveReplicaSet: "foo-1",
+			Canary: &datadoghqv1alpha1.ExtendedDaemonSetStatusCanary{
+				ReplicaSet: "foo-2",
+				Nodes:      []string{},
+			},
+		},
+	}
+	extendeddaemonset2 := test.NewExtendedDaemonSet("bar", "foo", options2)
+
 	type fields struct {
 		client client.Client
 		scheme *runtime.Scheme
@@ -77,10 +102,11 @@ func TestReconcileExtendedDaemonSet_selectNodes(t *testing.T) {
 		canaryStatus *datadoghqv1alpha1.ExtendedDaemonSetStatusCanary
 	}
 	tests := []struct {
-		name    string
-		fields  fields
-		args    args
-		wantErr bool
+		name     string
+		fields   fields
+		args     args
+		wantErr  bool
+		wantFunc func(*datadoghqv1alpha1.ExtendedDaemonSetStatusCanary) bool
 	}{
 		{
 			name: "enough nodes",
@@ -130,6 +156,25 @@ func TestReconcileExtendedDaemonSet_selectNodes(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			name: "dedicated canary nodes",
+			fields: fields{
+				scheme: s,
+				client: fake.NewFakeClient([]runtime.Object{node1, node2, node3}...),
+			},
+			args: args{
+				spec:       &extendeddaemonset2.Spec,
+				replicaset: &datadoghqv1alpha1.ExtendedDaemonSetReplicaSet{},
+				canaryStatus: &datadoghqv1alpha1.ExtendedDaemonSetStatusCanary{
+					ReplicaSet: "foo",
+					Nodes:      []string{},
+				},
+			},
+			wantErr: false,
+			wantFunc: func(canaryStatus *datadoghqv1alpha1.ExtendedDaemonSetStatusCanary) bool {
+				return len(canaryStatus.Nodes) == 1 && canaryStatus.Nodes[0] == "node2"
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -140,6 +185,9 @@ func TestReconcileExtendedDaemonSet_selectNodes(t *testing.T) {
 			}
 			if err := r.selectNodes(reqLogger, tt.args.spec, tt.args.replicaset, tt.args.canaryStatus); (err != nil) != tt.wantErr {
 				t.Errorf("ReconcileExtendedDaemonSet.selectNodes() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantFunc != nil && !tt.wantFunc(tt.args.canaryStatus) {
+				t.Errorf("ReconcileExtendedDaemonSet.selectNodes() didn’t pass the post-run checks")
 			}
 		})
 	}
@@ -432,7 +480,7 @@ func TestReconcileExtendedDaemonSet_createNewReplicaSet(t *testing.T) {
 	eventBroadcaster := record.NewBroadcaster()
 
 	logf.SetLogger(logf.ZapLogger(true))
-	log = logf.Log.WithName("TestReconcileExtendedDaemonSet_selectNodes")
+	log = logf.Log.WithName("TestReconcileExtendedDaemonSet_createNewReplicaSet")
 
 	// Register operator types with the runtime scheme.
 	s := scheme.Scheme
@@ -491,7 +539,7 @@ func TestReconcileExtendedDaemonSet_updateStatusWithNewRS(t *testing.T) {
 	eventBroadcaster := record.NewBroadcaster()
 
 	logf.SetLogger(logf.ZapLogger(true))
-	log = logf.Log.WithName("TestReconcileExtendedDaemonSet_selectNodes")
+	log = logf.Log.WithName("TestReconcileExtendedDaemonSet_updateStatusWithNewRS")
 
 	// Register operator types with the runtime scheme.
 	s := scheme.Scheme

--- a/pkg/controller/extendeddaemonset/extendeddaemonset_controller_test.go
+++ b/pkg/controller/extendeddaemonset/extendeddaemonset_controller_test.go
@@ -897,7 +897,7 @@ func newRequest(ns, name string) reconcile.Request {
 	}
 }
 
-func Test_antiAffinityKeysValue(t *testing.T) {
+func Test_getAntiAffinityKeysValue(t *testing.T) {
 	node := commontest.NewNode("node", &commontest.NewNodeOptions{
 		Labels: map[string]string{
 			"app":     "foo",
@@ -931,9 +931,9 @@ func Test_antiAffinityKeysValue(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := antiAffinityKeysValue(&tt.node, &tt.daemonsetSpec)
+			got := getAntiAffinityKeysValue(&tt.node, &tt.daemonsetSpec)
 			if got != tt.want {
-				t.Errorf("antiAffinityKeysValue(%#v, %#v) = %s, want %s", tt.node, tt.daemonsetSpec, got, tt.want)
+				t.Errorf("getAntiAffinityKeysValue(%#v, %#v) = %s, want %s", tt.node, tt.daemonsetSpec, got, tt.want)
 			}
 		})
 	}

--- a/pkg/controller/extendeddaemonsetreplicaset/ddaemonsetreplicaset_controller.go
+++ b/pkg/controller/extendeddaemonsetreplicaset/ddaemonsetreplicaset_controller.go
@@ -367,7 +367,7 @@ func (r *ReconcileExtendedDaemonSetReplicaSet) getNodeList(eds *datadoghqv1alpha
 
 	listOptions := []client.ListOption{}
 	if replicaset.Spec.Selector != nil {
-		selector, err := utils.LabelSelector2LabelSelector(log, replicaset.Spec.Selector)
+		selector, err := utils.ConvertLabelSelector(log, replicaset.Spec.Selector)
 		if err != nil {
 			return nil, err
 		}
@@ -427,7 +427,7 @@ func (r *ReconcileExtendedDaemonSetReplicaSet) getOldDaemonsetPodList(ds *datado
 	}
 	podListOptions := []client.ListOption{}
 	if oldDaemonset.Spec.Selector != nil {
-		selector, err2 := utils.LabelSelector2LabelSelector(log, oldDaemonset.Spec.Selector)
+		selector, err2 := utils.ConvertLabelSelector(log, oldDaemonset.Spec.Selector)
 		if err2 != nil {
 			return nil, err2
 		}

--- a/pkg/controller/extendeddaemonsetreplicaset/ddaemonsetreplicaset_controller.go
+++ b/pkg/controller/extendeddaemonsetreplicaset/ddaemonsetreplicaset_controller.go
@@ -38,6 +38,7 @@ import (
 	"github.com/datadog/extendeddaemonset/pkg/config"
 	"github.com/datadog/extendeddaemonset/pkg/controller/extendeddaemonsetreplicaset/conditions"
 	"github.com/datadog/extendeddaemonset/pkg/controller/extendeddaemonsetreplicaset/strategy"
+	"github.com/datadog/extendeddaemonset/pkg/controller/utils"
 	"github.com/datadog/extendeddaemonset/pkg/controller/utils/enqueue"
 )
 
@@ -363,14 +364,19 @@ func (r *ReconcileExtendedDaemonSetReplicaSet) getPodList(ds *datadoghqv1alpha1.
 
 func (r *ReconcileExtendedDaemonSetReplicaSet) getNodeList(eds *datadoghqv1alpha1.ExtendedDaemonSet, replicaset *datadoghqv1alpha1.ExtendedDaemonSetReplicaSet) (*strategy.NodeList, error) {
 	nodeItemList := &strategy.NodeList{}
-	nodeSelector := labels.Set{}
+
+	listOptions := []client.ListOption{}
 	if replicaset.Spec.Selector != nil {
-		nodeSelector = labels.Set(replicaset.Spec.Selector.MatchLabels)
-	}
-	listOptions := []client.ListOption{
-		client.MatchingLabelsSelector{
-			Selector: nodeSelector.AsSelectorPreValidated(),
-		},
+		selector, err := utils.LabelSelector2LabelSelector(log, replicaset.Spec.Selector)
+		if err != nil {
+			return nil, err
+		}
+
+		listOptions = []client.ListOption{
+			client.MatchingLabelsSelector{
+				Selector: selector,
+			},
+		}
 	}
 	nodeList := &corev1.NodeList{}
 	if err := r.client.List(context.TODO(), nodeList, listOptions...); err != nil {
@@ -419,15 +425,20 @@ func (r *ReconcileExtendedDaemonSetReplicaSet) getOldDaemonsetPodList(ds *datado
 		// Error reading the object - requeue the request.
 		return nil, err
 	}
-	var podSelector labels.Set
+	podListOptions := []client.ListOption{}
 	if oldDaemonset.Spec.Selector != nil {
-		podSelector = labels.Set(oldDaemonset.Spec.Selector.MatchLabels)
+		selector, err2 := utils.LabelSelector2LabelSelector(log, oldDaemonset.Spec.Selector)
+		if err2 != nil {
+			return nil, err2
+		}
+
+		podListOptions = []client.ListOption{
+			client.MatchingLabelsSelector{
+				Selector: selector,
+			},
+		}
 	}
-	podListOptions := []client.ListOption{
-		client.MatchingLabelsSelector{
-			Selector: podSelector.AsSelectorPreValidated(),
-		},
-	}
+
 	if err = r.client.List(context.TODO(), podList, podListOptions...); err != nil {
 		return nil, err
 	}

--- a/pkg/controller/extendeddaemonsetreplicaset/scheduler/predicates.go
+++ b/pkg/controller/extendeddaemonsetreplicaset/scheduler/predicates.go
@@ -26,12 +26,12 @@ import (
 func CheckNodeFitness(logger logr.Logger, pod *corev1.Pod, node *corev1.Node, ignoreNotReady bool) bool {
 	// Check pod node selector
 	// Check if node.Labels match pod.Spec.NodeSelector.
-	if !chechNodeSelector(pod, node) {
+	if !checkNodeSelector(pod, node) {
 		logger.V(1).Info("CheckNodeFitness return false", "reason", "node selector missmatch")
 		return false
 	}
 
-	if !chechPodToleratesNodeTaints(pod, node) {
+	if !checkPodToleratesNodeTaints(pod, node) {
 		logger.V(1).Info("CheckNodeFitness return false", "reason", "node taints")
 		return false
 	}
@@ -54,7 +54,7 @@ func chechNodeStatusReady(node *corev1.Node) bool {
 	return false
 }
 
-func chechNodeSelector(pod *corev1.Pod, node *corev1.Node) bool {
+func checkNodeSelector(pod *corev1.Pod, node *corev1.Node) bool {
 	if len(pod.Spec.NodeSelector) > 0 {
 		selector := labels.SelectorFromSet(pod.Spec.NodeSelector)
 		if !selector.Matches(labels.Set(node.Labels)) {
@@ -81,7 +81,7 @@ func chechNodeSelector(pod *corev1.Pod, node *corev1.Node) bool {
 	return nodeAffinityMatches
 }
 
-func chechPodToleratesNodeTaints(pod *corev1.Pod, node *corev1.Node) bool {
+func checkPodToleratesNodeTaints(pod *corev1.Pod, node *corev1.Node) bool {
 	filter := func(t *corev1.Taint) bool {
 		return t.Effect == corev1.TaintEffectNoSchedule || t.Effect == corev1.TaintEffectNoExecute
 	}

--- a/pkg/controller/utils/labelselector.go
+++ b/pkg/controller/utils/labelselector.go
@@ -1,0 +1,50 @@
+package utils
+
+import (
+	"github.com/go-logr/logr"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
+)
+
+// LabelSelector2LabelSelector converts a "k8s.io/apimachinery/pkg/apis/meta/v1".LabelSelector as found in manifests spec section into a "k8s.io/apimachinery/pkg/labels".Selector to be used to filter list operations.
+func LabelSelector2LabelSelector(logger logr.Logger, inSelector *metav1.LabelSelector) (outSelector labels.Selector, err error) {
+	outSelector = labels.NewSelector()
+	if inSelector != nil {
+		for key, value := range inSelector.MatchLabels {
+			req, err2 := labels.NewRequirement(key, selection.In, []string{value})
+			if err2 != nil {
+				logger.Error(err, "NewRequirement")
+				err = err2
+				continue
+			}
+			outSelector = outSelector.Add(*req)
+		}
+
+		for _, expr := range inSelector.MatchExpressions {
+			var op selection.Operator
+			switch expr.Operator {
+			case metav1.LabelSelectorOpIn:
+				op = selection.In
+			case metav1.LabelSelectorOpNotIn:
+				op = selection.NotIn
+			case metav1.LabelSelectorOpExists:
+				op = selection.Exists
+			case metav1.LabelSelectorOpDoesNotExist:
+				op = selection.DoesNotExist
+			default:
+				logger.Info("Invalid Operator:", expr.Operator)
+				continue
+			}
+			req, err2 := labels.NewRequirement(expr.Key, op, expr.Values)
+			if err2 != nil {
+				logger.Error(err, "NewRequirement")
+				err = err2
+				continue
+			}
+			outSelector = outSelector.Add(*req)
+		}
+	}
+	return outSelector, err
+}

--- a/pkg/controller/utils/labelselector.go
+++ b/pkg/controller/utils/labelselector.go
@@ -8,8 +8,8 @@ import (
 	"k8s.io/apimachinery/pkg/selection"
 )
 
-// LabelSelector2LabelSelector converts a "k8s.io/apimachinery/pkg/apis/meta/v1".LabelSelector as found in manifests spec section into a "k8s.io/apimachinery/pkg/labels".Selector to be used to filter list operations.
-func LabelSelector2LabelSelector(logger logr.Logger, inSelector *metav1.LabelSelector) (outSelector labels.Selector, err error) {
+// ConvertLabelSelector converts a "k8s.io/apimachinery/pkg/apis/meta/v1".LabelSelector as found in manifests spec section into a "k8s.io/apimachinery/pkg/labels".Selector to be used to filter list operations.
+func ConvertLabelSelector(logger logr.Logger, inSelector *metav1.LabelSelector) (outSelector labels.Selector, err error) {
 	outSelector = labels.NewSelector()
 	if inSelector != nil {
 		for key, value := range inSelector.MatchLabels {

--- a/pkg/controller/utils/labelselector.go
+++ b/pkg/controller/utils/labelselector.go
@@ -9,15 +9,14 @@ import (
 )
 
 // ConvertLabelSelector converts a "k8s.io/apimachinery/pkg/apis/meta/v1".LabelSelector as found in manifests spec section into a "k8s.io/apimachinery/pkg/labels".Selector to be used to filter list operations.
-func ConvertLabelSelector(logger logr.Logger, inSelector *metav1.LabelSelector) (outSelector labels.Selector, err error) {
-	outSelector = labels.NewSelector()
+func ConvertLabelSelector(logger logr.Logger, inSelector *metav1.LabelSelector) (labels.Selector, error) {
+	outSelector := labels.NewSelector()
 	if inSelector != nil {
 		for key, value := range inSelector.MatchLabels {
-			req, err2 := labels.NewRequirement(key, selection.In, []string{value})
-			if err2 != nil {
+			req, err := labels.NewRequirement(key, selection.In, []string{value})
+			if err != nil {
 				logger.Error(err, "NewRequirement")
-				err = err2
-				continue
+				return outSelector, err
 			}
 			outSelector = outSelector.Add(*req)
 		}
@@ -37,14 +36,13 @@ func ConvertLabelSelector(logger logr.Logger, inSelector *metav1.LabelSelector) 
 				logger.Info("Invalid Operator:", expr.Operator)
 				continue
 			}
-			req, err2 := labels.NewRequirement(expr.Key, op, expr.Values)
-			if err2 != nil {
+			req, err := labels.NewRequirement(expr.Key, op, expr.Values)
+			if err != nil {
 				logger.Error(err, "NewRequirement")
-				err = err2
-				continue
+				return outSelector, err
 			}
 			outSelector = outSelector.Add(*req)
 		}
 	}
-	return outSelector, err
+	return outSelector, nil
 }

--- a/pkg/controller/utils/labelselector_test.go
+++ b/pkg/controller/utils/labelselector_test.go
@@ -10,9 +10,9 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 )
 
-func TestLabelSelector2LabelSelector(t *testing.T) {
+func TestConvertLabelSelector(t *testing.T) {
 	logf.SetLogger(logf.ZapLogger(true))
-	log := logf.Log.WithName("TestLabelSelector2LabelSelector")
+	log := logf.Log.WithName("TestConvertLabelSelector")
 
 	foobarReq, _ := labels.NewRequirement("foo", selection.In, []string{"bar"})
 	bazquxReq, _ := labels.NewRequirement("baz", selection.In, []string{"qux"})
@@ -57,13 +57,13 @@ func TestLabelSelector2LabelSelector(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			reqLogger := log.WithValues("test:", tt.name)
-			got, err := LabelSelector2LabelSelector(reqLogger, &tt.input)
+			got, err := ConvertLabelSelector(reqLogger, &tt.input)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("LabelSelector2LabelSelector() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("ConvertLabelSelector() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("LabelSelector2LabelSelector() = %#v, want %#v", got, tt.want)
+				t.Errorf("ConvertLabelSelector() = %#v, want %#v", got, tt.want)
 			}
 		})
 	}

--- a/pkg/controller/utils/labelselector_test.go
+++ b/pkg/controller/utils/labelselector_test.go
@@ -1,0 +1,70 @@
+package utils
+
+import (
+	"reflect"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+)
+
+func TestLabelSelector2LabelSelector(t *testing.T) {
+	logf.SetLogger(logf.ZapLogger(true))
+	log := logf.Log.WithName("TestLabelSelector2LabelSelector")
+
+	foobarReq, _ := labels.NewRequirement("foo", selection.In, []string{"bar"})
+	bazquxReq, _ := labels.NewRequirement("baz", selection.In, []string{"qux"})
+
+	tests := []struct {
+		name    string
+		input   metav1.LabelSelector
+		want    labels.Selector
+		wantErr bool
+	}{
+		{
+			name: "match labels",
+			input: metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"foo": "bar",
+					"baz": "qux",
+				},
+			},
+			want:    labels.NewSelector().Add(*foobarReq).Add(*bazquxReq),
+			wantErr: false,
+		},
+		{
+			name: "match expressions",
+			input: metav1.LabelSelector{
+				MatchExpressions: []metav1.LabelSelectorRequirement{
+					{
+						Key:      "foo",
+						Operator: metav1.LabelSelectorOpIn,
+						Values:   []string{"bar"},
+					},
+					{
+						Key:      "baz",
+						Operator: metav1.LabelSelectorOpIn,
+						Values:   []string{"qux"},
+					},
+				},
+			},
+			want:    labels.NewSelector().Add(*foobarReq).Add(*bazquxReq),
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reqLogger := log.WithValues("test:", tt.name)
+			got, err := LabelSelector2LabelSelector(reqLogger, &tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("LabelSelector2LabelSelector() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("LabelSelector2LabelSelector() = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR adds two features to select canary nodes in a more fine-grained way:
* a node selector to choose the canary nodes: only the nodes matching the selector will be eligible to be used as canary.
  Ex. of use:
  ```yaml
  spec:
    strategy:
      canary:
        nodeSelector:
          matchExpressions:
          - key: canary
            operator: In
            values:
            - "true"
  ```
* a node anti-affinity feature: given a set of label keys, the canary nodes will be chosen so that the corresponding label values are different.
  Ex. of use:
  ```yaml
  spec:
    strategy:
      canary:
        nodeAntiAffinityKeys:
        - service
  ```
