### PR TITLE
Fix exclude nodes feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,11 +208,11 @@ spec:
         memory: "300m"
 ```
 
-#### Remove a pod on a given node using `matchExpressions`
+#### Remove a pod on a given node using `nodeAffinity`
 
-In some cases, it could be useful to remove a daemon pod on a given node. This can be done using the `selector` field.
+In some cases, it could be useful to remove a daemon pod on a given node. This can be done using the `podTemplate.spec.affinity.nodeAffinity` field.
 
-First set the `selector` field
+First set a new `requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms` field
 
 ```yaml
 apiVersion: datadoghq.com/v1alpha1
@@ -220,16 +220,18 @@ kind: ExtendedDaemonSet
 metadata:
   name: foo
 spec:
-  selector:
-    matchExpressions:
-      - {key: extendeddaemonset.datadoghq.com/exclude, operator: NotIn, values: [foo]}
   template:
     spec:
-      containers:
-      - name: daemon
-        image: k8s.gcr.io/pause:3.0
-      tolerations:
-      - operator: Exists
+      //...
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: extendeddaemonset.datadoghq.com/exclude
+                operator: NotIn
+                values:
+                - foo
 ```
 
 Then add the label `extendeddaemonset.datadoghq.com/exclude=foo` to the node in question

--- a/examples/foo-eds_exclude-node.yaml
+++ b/examples/foo-eds_exclude-node.yaml
@@ -1,0 +1,31 @@
+apiVersion: datadoghq.com/v1alpha1
+kind: ExtendedDaemonSet
+metadata:
+  name: foo
+spec:
+  strategy:
+    canary:
+      replicas: 1
+      duration: 5m
+    rollingUpdate:
+      maxParallelPodCreation: 1
+      slowStartIntervalDuration: 1m
+  template:
+    spec: 
+      containers:
+      - name: daemon
+        image: k8s.gcr.io/pause:3.0
+      tolerations:
+      - operator: Exists
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: extendeddaemonset.datadoghq.com/exclude
+                operator: NotIn
+                values:
+                - foo
+
+
+

--- a/pkg/controller/extendeddaemonset/extendeddaemonset_controller.go
+++ b/pkg/controller/extendeddaemonset/extendeddaemonset_controller.go
@@ -325,16 +325,6 @@ func (r *ReconcileExtendedDaemonSet) selectNodes(logger logr.Logger, daemonsetSp
 	nodeList := &corev1.NodeList{}
 
 	listOptions := []client.ListOption{}
-	if replicaset.Spec.Selector != nil {
-		selector, err := utils.ConvertLabelSelector(logger, replicaset.Spec.Selector)
-		if err != nil {
-			logger.Error(err, "Failed to parse label selector")
-		} else {
-			listOptions = append(listOptions, &client.MatchingLabelsSelector{
-				Selector: selector,
-			})
-		}
-	}
 	if daemonsetSpec.Strategy.Canary.NodeSelector != nil {
 		selector, err := utils.ConvertLabelSelector(logger, daemonsetSpec.Strategy.Canary.NodeSelector)
 		if err != nil {

--- a/pkg/controller/utils/affinity/affinity.go
+++ b/pkg/controller/utils/affinity/affinity.go
@@ -54,7 +54,7 @@ func ReplaceNodeNameNodeAffinity(affinity *v1.Affinity, nodename string) *v1.Aff
 		return affinity
 	}
 
-	// Replace node selector with the new one.
+	// Build new NodeSelectorTerm list to add the Node name field selector
 	newSelectorTerms := []v1.NodeSelectorTerm{}
 	for _, term := range nodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms {
 		newTerm := term.DeepCopy()
@@ -62,14 +62,14 @@ func ReplaceNodeNameNodeAffinity(affinity *v1.Affinity, nodename string) *v1.Aff
 		if len(newTerm.MatchFields) == 0 {
 			newTerm.MatchFields = []v1.NodeSelectorRequirement{nodeSelReq}
 		} else {
-			keyNodeNameFounded := false
+			keyNodeNameFound := false
 			for id, matchField := range newTerm.MatchFields {
 				if matchField.Key == NodeFieldSelectorKeyNodeName {
 					newTerm.MatchFields[id] = nodeSelReq
-					keyNodeNameFounded = true
+					keyNodeNameFound = true
 				}
 			}
-			if !keyNodeNameFounded {
+			if !keyNodeNameFound {
 				newTerm.MatchFields = append(newTerm.MatchFields, nodeSelReq)
 			}
 		}

--- a/pkg/controller/utils/affinity/affinity_test.go
+++ b/pkg/controller/utils/affinity/affinity_test.go
@@ -1,0 +1,129 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2019 Datadog, Inc.
+
+package affinity
+
+import (
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
+)
+
+func TestReplaceNodeNameNodeAffinity(t *testing.T) {
+	nodeName := "foo-node"
+	nodeNameSelReq := v1.NodeSelectorRequirement{
+		Key:      NodeFieldSelectorKeyNodeName,
+		Operator: v1.NodeSelectorOpIn,
+		Values:   []string{nodeName},
+	}
+
+	nodeLabelExcludeSelReq := v1.NodeSelectorRequirement{
+		Key:      "extendeddaemonset.datadoghq.com/exclude",
+		Operator: v1.NodeSelectorOpIn,
+		Values:   []string{"true"},
+	}
+
+	type args struct {
+		affinity *v1.Affinity
+		nodename string
+	}
+	tests := []struct {
+		name string
+		args args
+		want *v1.Affinity
+	}{
+		{
+			name: "empty affinity",
+			args: args{
+				affinity: &v1.Affinity{},
+				nodename: nodeName,
+			},
+			want: &v1.Affinity{
+				NodeAffinity: &v1.NodeAffinity{
+					RequiredDuringSchedulingIgnoredDuringExecution: &v1.NodeSelector{
+						NodeSelectorTerms: []v1.NodeSelectorTerm{
+							{
+								MatchFields: []v1.NodeSelectorRequirement{nodeNameSelReq},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "affinity container another term",
+			args: args{
+				affinity: &v1.Affinity{
+					NodeAffinity: &v1.NodeAffinity{
+						RequiredDuringSchedulingIgnoredDuringExecution: &v1.NodeSelector{
+							NodeSelectorTerms: []v1.NodeSelectorTerm{
+								{
+									MatchExpressions: []v1.NodeSelectorRequirement{nodeLabelExcludeSelReq},
+								},
+							},
+						},
+					},
+				},
+				nodename: nodeName,
+			},
+			want: &v1.Affinity{
+				NodeAffinity: &v1.NodeAffinity{
+					RequiredDuringSchedulingIgnoredDuringExecution: &v1.NodeSelector{
+						NodeSelectorTerms: []v1.NodeSelectorTerm{
+							{
+								MatchFields:      []v1.NodeSelectorRequirement{nodeNameSelReq},
+								MatchExpressions: []v1.NodeSelectorRequirement{nodeLabelExcludeSelReq},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "override node name field selector if already set",
+			args: args{
+				affinity: &v1.Affinity{
+					NodeAffinity: &v1.NodeAffinity{
+						RequiredDuringSchedulingIgnoredDuringExecution: &v1.NodeSelector{
+							NodeSelectorTerms: []v1.NodeSelectorTerm{
+								{
+									MatchFields: []v1.NodeSelectorRequirement{
+										{
+											Key:      NodeFieldSelectorKeyNodeName,
+											Operator: v1.NodeSelectorOpIn,
+											Values:   []string{"previous-node-name"},
+										},
+									},
+									MatchExpressions: []v1.NodeSelectorRequirement{nodeLabelExcludeSelReq},
+								},
+							},
+						},
+					},
+				},
+				nodename: nodeName,
+			},
+			want: &v1.Affinity{
+				NodeAffinity: &v1.NodeAffinity{
+					RequiredDuringSchedulingIgnoredDuringExecution: &v1.NodeSelector{
+						NodeSelectorTerms: []v1.NodeSelectorTerm{
+							{
+								MatchFields:      []v1.NodeSelectorRequirement{nodeNameSelReq},
+								MatchExpressions: []v1.NodeSelectorRequirement{nodeLabelExcludeSelReq},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ReplaceNodeNameNodeAffinity(tt.args.affinity, tt.args.nodename); !apiequality.Semantic.DeepEqual(got, tt.want) {
+				t.Errorf("ReplaceNodeNameNodeAffinity() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
* Update documentation: how to exclude temporary nodes
* Fix the `selectNodes()` function that was using the Pod labelSelector
  to filter Nodes.
* Add some logic in the function that inject the NodeName field affinity
  to merge the NodeAffinity instead of replacing it.

## Test plan:
* deploy the `examples/foo-eds_exclude-node.yaml` EDS in a test cluster.
* wait to have all the daemonset pod created
* add the label on a node. for example: `kubectl label node kind-worker extendeddaemonset.datadoghq.com/exclude=foo --overwrite`
* the daemonset pod on the labeled node should be deleted
* remove the label`kubectl label node kind-worker extendeddaemonset.datadoghq.com/exclude- --overwrite`, the daemonset pod should be reschedule on the node.