### PR TITLE
Allow the EDS to deploy pods on unschedulable nodes

### DIFF
--- a/controllers/extendeddaemonset/controller.go
+++ b/controllers/extendeddaemonset/controller.go
@@ -323,7 +323,7 @@ func (r *Reconciler) selectNodes(logger logr.Logger, daemonsetSpec *datadoghqv1a
 			continue
 		}
 
-		if !scheduler.CheckNodeFitness(logger.WithValues("filter", "Nodes Unschedulabled"), newPod, &node, false) {
+		if !scheduler.CheckNodeFitness(logger.WithValues("filter", "Nodes Unschedulabled"), newPod, &node) {
 			currentNodes = append(currentNodes[:id], currentNodes[id+1:]...)
 		}
 	}

--- a/controllers/extendeddaemonsetreplicaset/filters.go
+++ b/controllers/extendeddaemonsetreplicaset/filters.go
@@ -51,7 +51,7 @@ func FilterAndMapPodsByNode(logger logr.Logger, replicaset *datadoghqv1alpha1.Ex
 			continue
 		}
 		// Filter Nodes Unschedulabled
-		if scheduler.CheckNodeFitness(logger.WithValues("filter", "FilterAndMapPodsByNode"), newPod, nodeItem.Node, false) {
+		if scheduler.CheckNodeFitness(logger.WithValues("filter", "FilterAndMapPodsByNode"), newPod, nodeItem.Node) {
 			podsByNodeName[nodeItem.Node.Name] = nil
 		} else {
 			logger.V(1).Info("CheckNodeFitness not ok", "reason", "DeletionTimestamp==nil", "node.Name", nodeItem.Node.Name)

--- a/controllers/extendeddaemonsetreplicaset/scheduler/predicates.go
+++ b/controllers/extendeddaemonsetreplicaset/scheduler/predicates.go
@@ -23,7 +23,7 @@ import (
 // the predicates include:
 //   - PodMatchNodeSelector: checks pod's NodeSelector and NodeAffinity against node
 //   - PodToleratesNodeTaints: exclude tainted node unless pod has specific toleration
-func CheckNodeFitness(logger logr.Logger, pod *corev1.Pod, node *corev1.Node, ignoreNotReady bool) bool {
+func CheckNodeFitness(logger logr.Logger, pod *corev1.Pod, node *corev1.Node) bool {
 	// Check pod node selector
 	// Check if node.Labels match pod.Spec.NodeSelector.
 	if !checkNodeSelector(pod, node) {
@@ -36,27 +36,7 @@ func CheckNodeFitness(logger logr.Logger, pod *corev1.Pod, node *corev1.Node, ig
 		return false
 	}
 
-	if ignoreNotReady && !chechNodeStatusReady(node) {
-		logger.V(1).Info("CheckNodeFitness return false", "reason", "node not ready")
-		return false
-	}
-
-	if node.Spec.Unschedulable {
-		logger.V(1).Info("CheckNodeFitness return false", "reason", "node unschedulable")
-		return false
-	}
-
 	return true
-}
-
-func chechNodeStatusReady(node *corev1.Node) bool {
-	// Return true only if node ready
-	for _, condition := range node.Status.Conditions {
-		if condition.Type == corev1.NodeReady && condition.Status == corev1.ConditionTrue {
-			return true
-		}
-	}
-	return false
 }
 
 func checkNodeSelector(pod *corev1.Pod, node *corev1.Node) bool {

--- a/controllers/extendeddaemonsetreplicaset/scheduler/predicates_test.go
+++ b/controllers/extendeddaemonsetreplicaset/scheduler/predicates_test.go
@@ -59,9 +59,8 @@ func TestCheckNodeFitness(t *testing.T) {
 	})
 
 	type args struct {
-		pod            *corev1.Pod
-		node           *corev1.Node
-		ignoreNotReady bool
+		pod  *corev1.Pod
+		node *corev1.Node
 	}
 	tests := []struct {
 		name string
@@ -71,34 +70,31 @@ func TestCheckNodeFitness(t *testing.T) {
 		{
 			name: "node ready",
 			args: args{
-				pod:            pod1,
-				node:           node1,
-				ignoreNotReady: false,
+				pod:  pod1,
+				node: node1,
 			},
 			want: true,
 		},
 		{
 			name: "node not ready",
 			args: args{
-				pod:            pod1,
-				node:           node2,
-				ignoreNotReady: false,
+				pod:  pod1,
+				node: node2,
 			},
 			want: true,
 		},
 		{
 			name: "node unschedulable",
 			args: args{
-				pod:            pod1,
-				node:           node3,
-				ignoreNotReady: false,
+				pod:  pod1,
+				node: node3,
 			},
-			want: false,
+			want: true,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := CheckNodeFitness(log.WithName(tt.name), tt.args.pod, tt.args.node, tt.args.ignoreNotReady); got != tt.want {
+			if got := CheckNodeFitness(log.WithName(tt.name), tt.args.pod, tt.args.node); got != tt.want {
 				t.Errorf("CheckNodeFitness() = %v, want %v", got, tt.want)
 			}
 		})

--- a/pkg/controller/test/new.go
+++ b/pkg/controller/test/new.go
@@ -17,6 +17,7 @@ type NewNodeOptions struct {
 	Annotations   map[string]string
 	Labels        map[string]string
 	Conditions    []corev1.NodeCondition
+	Taints        []corev1.Taint
 	Unschedulable bool
 }
 
@@ -48,6 +49,7 @@ func NewNode(name string, opts *NewNodeOptions) *corev1.Node {
 
 		node.Spec.Unschedulable = opts.Unschedulable
 		node.Status.Conditions = append(node.Status.Conditions, opts.Conditions...)
+		node.Spec.Taints = append(node.Spec.Taints, opts.Taints...)
 	}
 	return node
 }
@@ -61,6 +63,7 @@ type NewPodOptions struct {
 	Reason            string
 	Resources         corev1.ResourceRequirements
 	NodeSelector      map[string]string
+	Tolerations       []corev1.Toleration
 }
 
 // NewPod used to return new pod instance
@@ -109,6 +112,7 @@ func NewPod(namespace, name, nodeName string, opts *NewPodOptions) *corev1.Pod {
 		}
 		pod.Status.Phase = opts.Phase
 		pod.Status.Reason = opts.Reason
+		pod.Spec.Tolerations = append(pod.Spec.Tolerations, opts.Tolerations...)
 	}
 
 	if nodeName != "" {

--- a/pkg/controller/utils/pod/const.go
+++ b/pkg/controller/utils/pod/const.go
@@ -5,8 +5,53 @@
 
 package pod
 
+import (
+	corev1 "k8s.io/api/core/v1"
+)
+
 const (
 	// DaemonsetClusterAutoscalerPodAnnotationKey use to inform the cluster-autoscaler that a pod
 	// should be considered as a DaemonSet pod
 	DaemonsetClusterAutoscalerPodAnnotationKey = "cluster-autoscaler.kubernetes.io/daemonset-pod"
+)
+
+// Should be const but GO doesn't support const structures
+var (
+	// StandardDaemonSetTolerations contains the tolerations that the EDS controller should add to
+	// all pods it manages.
+	// For consistency, this list must be in sync with the tolerations that are automatically added
+	// by the regular kubernetes DaemonSet controller:
+	// https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/#taints-and-tolerations
+	StandardDaemonSetTolerations = []corev1.Toleration{
+		{
+			Key:      "node.kubernetes.io/not-ready",
+			Operator: corev1.TolerationOpExists,
+			Effect:   corev1.TaintEffectNoExecute,
+		},
+		{
+			Key:      "node.kubernetes.io/unreachable",
+			Operator: corev1.TolerationOpExists,
+			Effect:   corev1.TaintEffectNoExecute,
+		},
+		{
+			Key:      "node.kubernetes.io/disk-pressure",
+			Operator: corev1.TolerationOpExists,
+			Effect:   corev1.TaintEffectNoSchedule,
+		},
+		{
+			Key:      "node.kubernetes.io/memory-pressure",
+			Operator: corev1.TolerationOpExists,
+			Effect:   corev1.TaintEffectNoSchedule,
+		},
+		{
+			Key:      "node.kubernetes.io/unschedulable",
+			Operator: corev1.TolerationOpExists,
+			Effect:   corev1.TaintEffectNoSchedule,
+		},
+		{
+			Key:      "node.kubernetes.io/network-unavailable",
+			Operator: corev1.TolerationOpExists,
+			Effect:   corev1.TaintEffectNoSchedule,
+		},
+	}
 )

--- a/pkg/controller/utils/pod/create.go
+++ b/pkg/controller/utils/pod/create.go
@@ -43,6 +43,8 @@ func CreatePodFromDaemonSetReplicaSet(scheme *runtime.Scheme, replicaset *datado
 	templateCopy.ObjectMeta.Annotations[datadoghqv1alpha1.MD5ExtendedDaemonSetAnnotationKey] = replicaset.Spec.TemplateGeneration
 	templateCopy.ObjectMeta.Annotations[DaemonsetClusterAutoscalerPodAnnotationKey] = "true"
 
+	templateCopy.Spec.Tolerations = append(templateCopy.Spec.Tolerations, StandardDaemonSetTolerations...)
+
 	overwriteResourcesFromEdsNode(templateCopy, edsNode)
 
 	if node != nil {


### PR DESCRIPTION
### What does this PR do?

Allow the `ExtendedDaemonSet` controller to deploy pods on unschedulable nodes.

### Motivation

Have the same behaviour as with the regular Kubernetes `DaemonSet`.
https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/#taints-and-tolerations

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Cordon a node and check that the EDS controller still deploy a pod on it.