### PR TITLE
Fix helm chart configuration

### DIFF
--- a/chart/extendeddaemonset/templates/deployment.yaml
+++ b/chart/extendeddaemonset/templates/deployment.yaml
@@ -30,11 +30,9 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
-            - --zap-level={{ .Values.logLevel }}
-            - --zap-encoder=console
-            - --zap-stacktrace-level=error
+            - -loglevel={{ .Values.logLevel }}
           {{- if .Values.pprof.enabled }}
-            - --pprof=true
+            - -pprof
           {{- end }}
           env:
             - name: WATCH_NAMESPACE
@@ -53,18 +51,12 @@ spec:
               value: {{ .Chart.Name }}
           ports:
             - name: metrics
-              containerPort: 8383
+              containerPort: 8080
               protocol: TCP
-          readinessProbe:
-            httpGet:
-              path: /ready
-              port: 8080
-            periodSeconds: 10
           livenessProbe:
             httpGet:
-              path: /live
-              port: 8080
-            periodSeconds: 10
+              path: /healthz/
+              port: 8081
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}


### PR DESCRIPTION
### What does this PR do?

Update helm chart deployment:
* update container argument to match new process args introduced with the operator-sdk v1.0.0 migration.
* update liveness probe configuration and remove readiness problem.
* update metrics port.

### Motivation

Update the helm chart to be compatible with the new `extendeddaemonset` controller process.

### Additional Notes

I used kustomize config that is now used for testing as reference:  https://github.com/DataDog/extendeddaemonset/blob/master/config/manager/manager.yaml 

### Describe your test plan

Build the `extendeddaemonset` docker image from master HEAD, or with RC image. deploy the `extendeddaemonset` controller with the helm chart. the controller should start properly.
