### PR TITLE
fix CRDs path in helm chart

### DIFF
--- a/chart/extendeddaemonset/crds/datadoghq.com_extendeddaemonsetreplicasets.yaml
+++ b/chart/extendeddaemonset/crds/datadoghq.com_extendeddaemonsetreplicasets.yaml
@@ -1,0 +1,1 @@
+../../../bundle/manifests/datadoghq.com_extendeddaemonsetreplicasets.yaml

--- a/chart/extendeddaemonset/crds/datadoghq.com_extendeddaemonsetreplicasets_crd.yaml
+++ b/chart/extendeddaemonset/crds/datadoghq.com_extendeddaemonsetreplicasets_crd.yaml
@@ -1,1 +1,0 @@
-../../../deploy/crds/datadoghq.com_extendeddaemonsetreplicasets_crd.yaml

--- a/chart/extendeddaemonset/crds/datadoghq.com_extendeddaemonsets.yaml
+++ b/chart/extendeddaemonset/crds/datadoghq.com_extendeddaemonsets.yaml
@@ -1,0 +1,1 @@
+../../../bundle/manifests/datadoghq.com_extendeddaemonsets.yaml

--- a/chart/extendeddaemonset/crds/datadoghq.com_extendeddaemonsets_crd.yaml
+++ b/chart/extendeddaemonset/crds/datadoghq.com_extendeddaemonsets_crd.yaml
@@ -1,1 +1,0 @@
-../../../deploy/crds/datadoghq.com_extendeddaemonsets_crd.yaml

--- a/chart/extendeddaemonset/crds/datadoghq.com_extendeddaemonsetsettings.yaml
+++ b/chart/extendeddaemonset/crds/datadoghq.com_extendeddaemonsetsettings.yaml
@@ -1,0 +1,1 @@
+../../../bundle/manifests/datadoghq.com_extendeddaemonsetsettings.yaml

--- a/chart/extendeddaemonset/crds/datadoghq.com_extendeddaemonsetsettings_crd.yaml
+++ b/chart/extendeddaemonset/crds/datadoghq.com_extendeddaemonsetsettings_crd.yaml
@@ -1,1 +1,0 @@
-../../../deploy/crds/datadoghq.com_extendeddaemonsetsettings_crd.yaml


### PR DESCRIPTION
### What does this PR do?

Fix the CRD's symlink in the helm chart.

### Motivation

ExtendedDaemonset controller installation with the helm chart was broken.

### Additional Notes

N/A

### Describe your test plan

Try to install the ExtendedDaemonset controller with the helm chart. Installation should
succeeded.
