### PR TITLE
fix leader election configmap name

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.13 as builder
+FROM golang:1.14 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/chart/extendeddaemonset/Chart.yaml
+++ b/chart/extendeddaemonset/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: v0.2.0
+appVersion: v0.3.0
 description: Extended Daemonset Controller
 name: extendeddaemonset
-version: v0.2.0
+version: v0.3.0

--- a/chart/extendeddaemonset/values.yaml
+++ b/chart/extendeddaemonset/values.yaml
@@ -5,7 +5,7 @@
 replicaCount: 1
 image:
   repository: datadog/extendeddaemonset
-  tag: v0.2.0
+  tag: v0.3.0
   pullPolicy: IfNotPresent
 imagePullSecrets: []
 nameOverride: ""

--- a/examples/foo-eds_exclude-node.yaml
+++ b/examples/foo-eds_exclude-node.yaml
@@ -1,0 +1,28 @@
+apiVersion: datadoghq.com/v1alpha1
+kind: ExtendedDaemonSet
+metadata:
+  name: foo
+spec:
+  strategy:
+    canary:
+      replicas: 1
+      duration: 5m
+    rollingUpdate:
+      maxParallelPodCreation: 1
+      slowStartIntervalDuration: 1m
+  template:
+    spec: 
+      containers:
+      - name: daemon
+        image: k8s.gcr.io/pause:3.0
+      tolerations:
+      - operator: Exists
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: extendeddaemonset.datadoghq.com/exclude
+                operator: NotIn
+                values:
+                - foo

--- a/examples/foo-eds_v1.yaml
+++ b/examples/foo-eds_v1.yaml
@@ -1,0 +1,19 @@
+apiVersion: datadoghq.com/v1alpha1
+kind: ExtendedDaemonSet
+metadata:
+  name: foo
+spec:
+  strategy:
+    canary:
+      replicas: 1
+      duration: 5m
+    rollingUpdate:
+      maxParallelPodCreation: 1
+      slowStartIntervalDuration: 1m
+  template:
+    spec: 
+      containers:
+      - name: daemon
+        image: k8s.gcr.io/pause:3.0
+      tolerations:
+      - operator: Exists

--- a/examples/foo-eds_v2.yaml
+++ b/examples/foo-eds_v2.yaml
@@ -1,0 +1,19 @@
+apiVersion: datadoghq.com/v1alpha1
+kind: ExtendedDaemonSet
+metadata:
+  name: foo
+spec:
+  strategy:
+    canary:
+      replicas: 1
+      duration: 5m
+    rollingUpdate:
+      maxParallelPodCreation: 1
+      slowStartIntervalDuration: 1m
+  template:
+    spec: 
+      containers:
+      - name: daemon
+        image: k8s.gcr.io/pause:3.1
+      tolerations:
+      - operator: Exists

--- a/main.go
+++ b/main.go
@@ -85,7 +85,7 @@ func main() {
 		HealthProbeBindAddress: ":8081",
 		Port:                   9443,
 		LeaderElection:         enableLeaderElection,
-		LeaderElectionID:       "e361fbac.datadoghq.com",
+		LeaderElectionID:       "extendeddaemonset-lock",
 	}))
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")


### PR DESCRIPTION
### What does this PR do?

* fix name of leader-election's configmap
* Update chart version.
* Update docker tag in helm chart.
* Update golang version.
* Add back examples folder.

### Motivation

Helm chart regression detected during QA.

### Additional Notes

### Describe your test plan

Deploy the EDS-controller with the helm chart. Check logs to validate that
leader-election configmap RBAC error is not present. 

