### PR TITLE
Add eds_controller_leader gauge to identify leader from /metrics and /ksmetrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,7 +286,7 @@ CGO_ENABLED=0 go build -i -installsuffix cgo -ldflags '-w' -o controller ./cmd/m
 You can create (and deploy) a custom image easily through the `IMG` environment variable:
 
 ```
-IMG=<your_dockerhub_repo>/extendeddaemonset:test make docker-build deploy
+IMG=<your_dockerhub_repo>/extendeddaemonset:test make docker-build docker-push deploy
 ```
 
 #### Unit tests

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,8 @@ require (
 	github.com/olekukonko/tablewriter v0.0.0-20170122224234-a0225b3f23b5
 	github.com/onsi/ginkgo v1.12.1
 	github.com/onsi/gomega v1.10.1
+	github.com/prometheus/client_golang v1.1.0
+	github.com/prometheus/common v0.6.0
 	github.com/spf13/cobra v0.0.5
 	github.com/spf13/pflag v1.0.5
 	go.uber.org/zap v1.10.0

--- a/main.go
+++ b/main.go
@@ -98,6 +98,7 @@ func main() {
 	}
 
 	// Custom setup
+	customSetupMetrics(mgr)
 	customSetupEnvironment(mgr)
 	customSetupHealthChecks(mgr)
 	customSetupEndpoints(pprofActive, mgr)
@@ -149,6 +150,16 @@ func customSetupEnvironment(mgr manager.Manager) {
 			}
 		}
 	}
+}
+
+func customSetupMetrics(mgr manager.Manager) {
+	go func() {
+		// This channel is closed when this instance is elected leader
+		// Apparently there's no releasing the lease except if application dies
+		<-mgr.Elected()
+		setupLog.Info("Controller elected - metric changed")
+		metrics.SetLeader(true)
+	}()
 }
 
 func customSetupLogging(logLevel zapcore.Level, logEncoder string) error {

--- a/pkg/controller/metrics/leader.go
+++ b/pkg/controller/metrics/leader.go
@@ -1,0 +1,42 @@
+package metrics
+
+import (
+	"strconv"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+const (
+	leaderLabel = "leader"
+)
+
+var (
+	isLeader  = false
+	edsLeader = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "eds_controller_leader",
+			Help: "Whether EDS instance is currently leader not",
+		}, []string{
+			leaderLabel,
+		},
+	)
+)
+
+// SetLeader sets the edsLeader gauge
+func SetLeader(leaderValue bool) {
+	if isLeader != leaderValue {
+		edsLeader.Delete(prometheus.Labels{leaderLabel: strconv.FormatBool(isLeader)})
+	}
+
+	isLeader = leaderValue
+	edsLeader.With(prometheus.Labels{leaderLabel: strconv.FormatBool(isLeader)}).Set(1)
+}
+
+func init() {
+	SetLeader(false)
+	// Register custom metrics with the global prometheus registry
+	metrics.Registry.MustRegister(edsLeader)
+	// Register custom metrics with KSMetrics registry
+	ksmExtraMetricsRegistry.MustRegister(edsLeader)
+}


### PR DESCRIPTION
### What does this PR do?

Add eds_controller_leader gauge to identify leader from `/metrics` and `/ksmetrics`

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Spawn two replicas of EDS instance, run 
`k exec -ti $POD -- curl http://localhost:8080/metrics`
`k exec -ti $POD -- curl http://localhost:8080/ksmetrics`

You should see `eds_controller_leader` set to 1 with `leader: true` or `leader: false` if leader or follower.