### PR TITLE
Add a canary pod label

### DIFF
--- a/api/v1alpha1/const.go
+++ b/api/v1alpha1/const.go
@@ -10,6 +10,10 @@ const (
 	ExtendedDaemonSetNameLabelKey = "extendeddaemonset.datadoghq.com/name"
 	// ExtendedDaemonSetReplicaSetNameLabelKey label key use to link a Pod to a ExtendedDaemonSetReplicaSet
 	ExtendedDaemonSetReplicaSetNameLabelKey = "extendeddaemonsetreplicaset.datadoghq.com/name"
+	// ExtendedDaemonSetReplicaSetCanaryLabelKey label key used to identify canary Pods
+	ExtendedDaemonSetReplicaSetCanaryLabelKey = "extendeddaemonsetreplicaset.datadoghq.com/canary"
+	// ExtendedDaemonSetReplicaSetCanaryLabelValue label value used to identify canary Pods
+	ExtendedDaemonSetReplicaSetCanaryLabelValue = "true"
 	// MD5ExtendedDaemonSetAnnotationKey annotation key use on Pods in order to identify which PodTemplateSpec have been used to generate it.
 	MD5ExtendedDaemonSetAnnotationKey = "extendeddaemonset.datadoghq.com/templatehash"
 	// ExtendedDaemonSetCanaryValidAnnotationKey annotation key used on Pods in order to detect if a canary deployment is considered valid.

--- a/controllers/extendeddaemonsetreplicaset/strategy/utils.go
+++ b/controllers/extendeddaemonsetreplicaset/strategy/utils.go
@@ -158,3 +158,29 @@ func pauseCanaryDeployment(client client.Client, eds *datadoghqv1alpha1.Extended
 	}
 	return nil
 }
+
+// addPodLabel adds a given label to a pod, no-op if the pod is nil or if the label exists
+func addPodLabel(c client.Client, pod *corev1.Pod, k, v string) error {
+	if pod == nil {
+		return nil
+	}
+	if label, found := pod.GetLabels()[k]; found && label == v {
+		// The label is there, nothing to do
+		return nil
+	}
+	pod.Labels[k] = v
+	return c.Update(context.TODO(), pod)
+}
+
+// deletePodLabel deletes a given pod label, no-op if the pod is nil or if the label doesn't exists
+func deletePodLabel(c client.Client, pod *corev1.Pod, k string) error {
+	if pod == nil {
+		return nil
+	}
+	if _, found := pod.GetLabels()[k]; !found {
+		// The label is not there, nothing to do
+		return nil
+	}
+	delete(pod.Labels, k)
+	return c.Update(context.TODO(), pod)
+}


### PR DESCRIPTION
### What does this PR do?

Add the label `extendeddaemonsetreplicaset.datadoghq.com/canary=true` as canary pods label

### Motivation

Ease monitoring canary pods

### Describe your test plan

- Start a canary deploy
- Canary pods must have the `extendeddaemonsetreplicaset.datadoghq.com/canary=true` label (`k get po -l extendeddaemonsetreplicaset.datadoghq.com/canary=true`)
- Validate the canary `k eds canary validate <eds-name>`
- `k get po -l extendeddaemonsetreplicaset.datadoghq.com/canary=true` must return `No resources found`
