### PR TITLE
Add extendeddaemonset-check helper

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2,6 +2,7 @@ image: golang:1.13
 variables:
   GO111MODULE: "on"
   PROJECTNAME: "extendeddaemonset"
+  PROJECTNAME_CHECK: "extendeddaemonset-check"
   GOPATH: "$CI_PROJECT_DIR/.cache"
   TARGET_TAG: v$CI_PIPELINE_ID-$CI_COMMIT_SHORT_SHA
   DOCKER_REGISTRY: "486234852809.dkr.ecr.us-east-1.amazonaws.com/ci"
@@ -40,33 +41,33 @@ generate_code:
   - make generate manifests
   - git diff --exit-code
 
-build_image:
+build_images:
   stage: image
   tags: [ "runner:docker", "size:large" ]
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/docker-notary:0.6.1
   before_script: []
   script:
-    - IMG=$DOCKER_REGISTRY/$PROJECTNAME:$TARGET_TAG make docker-build-ci docker-push
+    - IMG=$DOCKER_REGISTRY/$PROJECTNAME:$TARGET_TAG make docker-build-ci docker-push-ci
+    - IMG_CHECK=$DOCKER_REGISTRY/$PROJECTNAME_CHECK:$TARGET_TAG make docker-build-check-ci docker-push-check-ci
 
-push_release_tag:
-  only:
-    - tags
-  stage: release
-  tags: [ "runner:docker", "size:large" ]
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/docker-notary:0.6.1
-  before_script: []
-  script:
-    - IMAGE_NAME=$DOCKER_REGISTRY/$PROJECTNAME:$TARGET_TAG
-    - RELEASE_IMAGE_NAME=$DOCKER_REGISTRY/$PROJECTNAME:$CI_COMMIT_TAG
-    - docker pull $IMAGE_NAME
-    - docker tag $IMAGE_NAME $RELEASE_IMAGE_NAME
-    - docker push $RELEASE_IMAGE_NAME
+push_release_tag_controller:
+  extends: .push_release_tag
+  variables:
+    IMAGE_NAME: $DOCKER_REGISTRY/$PROJECTNAME:$TARGET_TAG
+    RELEASE_IMAGE_NAME: $DOCKER_REGISTRY/$PROJECTNAME:$CI_COMMIT_TAG
+
+.docker_env_tag_check:
+  extends: .push_release_tag
+  variables:
+    IMAGE_NAME: $DOCKER_REGISTRY/$PROJECTNAME_CHECK:$TARGET_TAG
+    RELEASE_IMAGE_NAME: $DOCKER_REGISTRY/$PROJECTNAME_CHECK:$CI_COMMIT_TAG
 
 .docker_hub_variables: &docker_hub_variables
   DOCKER_REGISTRY_LOGIN_SSM_KEY: docker_hub_login
   DOCKER_REGISTRY_PWD_SSM_KEY: docker_hub_pwd
   DOCKER_REGISTRY_URL: docker.io
   DOCKERHUB_REPO: extendeddaemonset
+  DOCKERHUB_REPO_CHECK: extendeddaemonset-check
   DOCKERHUB_ORG: datadog
 
 push_tag_to_docker_hub:
@@ -82,7 +83,8 @@ push_tag_to_docker_hub:
   script:
     - DOCKER_REGISTRY_LOGIN=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-operator.$DOCKER_REGISTRY_LOGIN_SSM_KEY --with-decryption --query "Parameter.Value" --out text)
     - aws ssm get-parameter --region us-east-1 --name ci.datadog-operator.$DOCKER_REGISTRY_PWD_SSM_KEY --with-decryption --query "Parameter.Value" --out text | docker login --username "$DOCKER_REGISTRY_LOGIN" --password-stdin $DOCKER_REGISTRY_URL
-    - IMG=$DOCKERHUB_ORG/$DOCKERHUB_REPO:${CI_COMMIT_TAG:1} make docker-build-ci docker-push
+    - IMG=$DOCKERHUB_ORG/$DOCKERHUB_REPO:${CI_COMMIT_TAG:1} make docker-build-ci docker-push-ci
+    - IMG_CHECK=$DOCKERHUB_ORG/$DOCKERHUB_REPO_CHECK:${CI_COMMIT_TAG:1} make docker-build-check-ci docker-push-check-ci
 
 push_latest_to_docker_hub:
   only:
@@ -97,4 +99,18 @@ push_latest_to_docker_hub:
   script:
     - DOCKER_REGISTRY_LOGIN=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-operator.$DOCKER_REGISTRY_LOGIN_SSM_KEY --with-decryption --query "Parameter.Value" --out text)
     - aws ssm get-parameter --region us-east-1 --name ci.datadog-operator.$DOCKER_REGISTRY_PWD_SSM_KEY --with-decryption --query "Parameter.Value" --out text | docker login --username "$DOCKER_REGISTRY_LOGIN" --password-stdin $DOCKER_REGISTRY_URL
-    - IMG=$DOCKERHUB_ORG/$DOCKERHUB_REPO:latest make docker-build-ci docker-push
+    - IMG=$DOCKERHUB_ORG/$DOCKERHUB_REPO:latest make docker-build-ci docker-push-ci
+    - IMG_CHECK=$DOCKERHUB_ORG/$DOCKERHUB_REPO_CHECK:latest make docker-build-check-ci docker-push-check-ci
+
+
+.push_release_tag:
+  only:
+    - tags
+  stage: release
+  tags: [ "runner:docker", "size:large" ]
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/docker-notary:0.6.1
+  before_script: []
+  script:
+    - docker pull $IMAGE_NAME
+    - docker tag $IMAGE_NAME $RELEASE_IMAGE_NAME
+    - docker push $RELEASE_IMAGE_NAME

--- a/chart/app-example/.helmignore
+++ b/chart/app-example/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/chart/app-example/Chart.yaml
+++ b/chart/app-example/Chart.yaml
@@ -1,0 +1,23 @@
+apiVersion: v2
+name: app-example
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+appVersion: 1.16.0

--- a/chart/app-example/README.md
+++ b/chart/app-example/README.md
@@ -1,0 +1,45 @@
+# APP Example
+
+## Introduction
+
+This chart allows you to deploy a "dummy" application that used the ExtendedDaemonset.
+
+thanks to this chart you can test several ExtendedDaemonset features, such as:
+
+* The Canary deployment strategy
+* The `extendeddaemonset-check` util pod with the `helm test` command.
+* The possibility to override a `Pod` resources for a specific `Node` thanks to an
+  `ExtendedDaemonsetSettings` resource.
+
+## Deployment
+
+Before deploying this chart, you should have deployed the `ExtendedDaemonset` Controller with the following.
+command: `helm install eds-controller ./chart/extendeddaemonset`.
+
+Now you can deploy the `app-example` with default values this: `helm install foo ./chart/app-example`.
+
+### Canary deployment
+
+### Check if a canary deployment finished
+
+Helm3 introduces the `helm test` command, which can be used to validate a "complex" deployment, was looking only
+at the state if the pod is not enough. It is also useful when the chart contains CRDs because Helm is not aware
+of how to understand the status of a CRD.
+
+This chart contains a test "Pod" (manifests present in `app-example/templates/tests`) that can check if a
+Extendedaemonset update is finished.
+
+To simulate an update, the following command will update the docker image tag for the "foo" application:
+`helm upgrade foo ./chart/app-example --set image.tag=stable`.
+
+The `ExtendedDaemonset` status should have been moved to `canary`
+
+```console
+$ kubectl get eds
+NAME              DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   IGNORED UNRESPONSIVE NODES   STATUS   REASON   ACTIVE RS               CANARY RS               AGE
+foo-app-example   3         3         3       3            3                                        Canary            foo-app-example-db2sk   foo-app-example-76kz8   1h
+```
+
+With the default configuration, the Canary deployment is set to 3min. During this period only one pod has been updated.
+
+The command `helm test foo` starts a Pod with a specific container that checks the `ExtendedDaemonset` status. The command returns when the canary deployment and the rolling-up are finished.

--- a/chart/app-example/README.md
+++ b/chart/app-example/README.md
@@ -2,9 +2,9 @@
 
 ## Introduction
 
-This chart allows you to deploy a "dummy" application that used the ExtendedDaemonset.
+This chart allows you to deploy a "dummy" application that uses the ExtendedDaemonset.
 
-thanks to this chart you can test several ExtendedDaemonset features, such as:
+Thanks to this chart you can test several ExtendedDaemonset features, such as:
 
 * The Canary deployment strategy
 * The `extendeddaemonset-check` util pod with the `helm test` command.
@@ -13,8 +13,7 @@ thanks to this chart you can test several ExtendedDaemonset features, such as:
 
 ## Deployment
 
-Before deploying this chart, you should have deployed the `ExtendedDaemonset` Controller with the following.
-command: `helm install eds-controller ./chart/extendeddaemonset`.
+Before deploying this chart, you should have deployed the `ExtendedDaemonset` Controller with the following command: `helm install eds-controller ./chart/extendeddaemonset`.
 
 Now you can deploy the `app-example` with default values this: `helm install foo ./chart/app-example`.
 

--- a/chart/app-example/templates/_helpers.tpl
+++ b/chart/app-example/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "app-example.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "app-example.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "app-example.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "app-example.labels" -}}
+helm.sh/chart: {{ include "app-example.chart" . }}
+{{ include "app-example.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "app-example.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "app-example.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "app-example.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "app-example.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/chart/app-example/templates/extendeddaemonset.yaml
+++ b/chart/app-example/templates/extendeddaemonset.yaml
@@ -24,6 +24,7 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.tolerations }}
       tolerations:
-      - operator: Exists
       {{- toYaml . | nindent 6 }}
+      {{- end }}

--- a/chart/app-example/templates/extendeddaemonset.yaml
+++ b/chart/app-example/templates/extendeddaemonset.yaml
@@ -1,0 +1,29 @@
+apiVersion: datadoghq.com/v1alpha1
+kind: ExtendedDaemonSet
+metadata:
+  name: {{ include "app-example.fullname" . }}
+  labels:
+    {{- include "app-example.labels" . | nindent 4 }}
+spec:
+  strategy:
+    {{- toYaml .Values.strategy | nindent 4 }}
+  template:
+    spec: 
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "app-example.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      tolerations:
+      - operator: Exists
+      {{- toYaml . | nindent 6 }}

--- a/chart/app-example/templates/serviceaccount.yaml
+++ b/chart/app-example/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "app-example.serviceAccountName" . }}
+  labels:
+    {{- include "app-example.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/chart/app-example/templates/tests/role.yaml
+++ b/chart/app-example/templates/tests/role.yaml
@@ -1,0 +1,34 @@
+{{- if .Values.rbac.create -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: "{{ include "app-example.fullname" . }}-test"
+  labels:
+    {{- include "app-example.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+rules:
+- apiGroups:
+  - datadoghq.com
+  resources:
+  - 'extendeddaemonsets'
+  - 'extendeddaemonsets/status'
+  verbs:
+  - 'get'
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: "{{ include "app-example.fullname" . }}-test"
+  labels:
+    {{- include "app-example.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+subjects:
+- kind: ServiceAccount
+  name: "{{ include "app-example.serviceAccountName" . }}-test"
+roleRef:
+  kind: Role
+  name: "{{ include "app-example.fullname" . }}-test"
+  apiGroup: rbac.authorization.k8s.io
+{{- end -}}

--- a/chart/app-example/templates/tests/service-account.yaml
+++ b/chart/app-example/templates/tests/service-account.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "app-example.serviceAccountName" . }}-test
+  labels:
+    {{- include "app-example.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/chart/app-example/templates/tests/test-update.yaml
+++ b/chart/app-example/templates/tests/test-update.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "app-example.fullname" . }}-test"
+  labels:
+    {{- include "app-example.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+spec:
+  serviceAccountName: {{ include "app-example.serviceAccountName" . }}-test
+  containers:
+    - name: {{ .Release.Name }}-check-eds
+      image: "{{ .Values.test.image.repository }}:{{ .Values.test.image.tag | default .Chart.AppVersion }}"
+      imagePullPolicy: {{ .Values.test.image.pullPolicy }}
+      args:
+        - upgrade
+        - -n={{ .Release.Namespace }}
+        - {{ include "app-example.fullname" . }}
+  restartPolicy: Never
+

--- a/chart/app-example/values.yaml
+++ b/chart/app-example/values.yaml
@@ -1,0 +1,75 @@
+# Default values for app-example.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  repository: nginx
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: "latest"
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+strategy:
+  canary:
+    replicas: 1
+    duration: 3m
+  rollingUpdate:
+    maxParallelPodCreation: 1
+    slowStartIntervalDuration: 1m
+
+test:
+  image:
+    repository: datadog/extendeddaemonset-check
+    pullPolicy: IfNotPresent
+    # Overrides the image tag whose default is the chart appVersion.
+    tag: "latest"
+rbac:
+  create: true
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+podAnnotations: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 100
+  targetCPUUtilizationPercentage: 80
+  # targetMemoryUtilizationPercentage: 80
+
+tolerations:

--- a/chart/app-example/values.yaml
+++ b/chart/app-example/values.yaml
@@ -2,8 +2,6 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-replicaCount: 1
-
 image:
   repository: nginx
   pullPolicy: IfNotPresent
@@ -20,7 +18,7 @@ strategy:
     duration: 3m
   rollingUpdate:
     maxParallelPodCreation: 1
-    slowStartIntervalDuration: 1m
+    slowStartInterval Duration: 1m
 
 test:
   image:
@@ -65,11 +63,5 @@ resources: {}
   #   cpu: 100m
   #   memory: 128Mi
 
-autoscaling:
-  enabled: false
-  minReplicas: 1
-  maxReplicas: 100
-  targetCPUUtilizationPercentage: 80
-  # targetMemoryUtilizationPercentage: 80
-
 tolerations:
+- operator: Exists

--- a/check-eds.Dockerfile
+++ b/check-eds.Dockerfile
@@ -1,0 +1,26 @@
+# Build the manager binary
+FROM golang:1.14 as builder
+
+WORKDIR /workspace
+# Copy the Go Modules manifests
+COPY go.mod go.mod
+COPY go.sum go.sum
+# cache deps before building and copying source so that we don't need to re-download as much
+# and so that source changes don't invalidate our downloaded layer
+RUN go mod download
+
+# Copy the go source
+COPY cmd/check-eds/ cmd/check-eds/
+COPY api/ api/
+COPY pkg/ pkg/
+
+# Build
+ARG LDFLAGS
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -ldflags "${LDFLAGS}" -o check-eds cmd/check-eds/main.go
+
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+WORKDIR /
+COPY --from=builder /workspace/check-eds .
+USER 1001
+
+ENTRYPOINT ["/check-eds"]

--- a/cmd/check-eds/main.go
+++ b/cmd/check-eds/main.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"os"
+
+	"github.com/spf13/pflag"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+
+	"github.com/DataDog/extendeddaemonset/cmd/check-eds/root"
+)
+
+// edscheck is use to validate a extendeddaemonset deployment
+// main usecase it to validate a helm deployment
+
+func main() {
+	flags := pflag.NewFlagSet("eds-checks", pflag.ExitOnError)
+	pflag.CommandLine = flags
+
+	root := root.NewCmdRoot(genericclioptions.IOStreams{In: os.Stdin, Out: os.Stdout, ErrOut: os.Stderr})
+	if err := root.Execute(); err != nil {
+		os.Exit(1)
+	}
+}

--- a/cmd/check-eds/root/root.go
+++ b/cmd/check-eds/root/root.go
@@ -1,0 +1,53 @@
+package root
+
+import (
+	"github.com/DataDog/extendeddaemonset/cmd/check-eds/upgrade"
+	"github.com/spf13/cobra"
+
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+)
+
+// Options provides information required to manage Root
+type Options struct {
+	configFlags *genericclioptions.ConfigFlags
+	genericclioptions.IOStreams
+}
+
+// NewRootOptions provides an instance of Options with default values
+func NewRootOptions(streams genericclioptions.IOStreams) *Options {
+	return &Options{
+		configFlags: genericclioptions.NewConfigFlags(false),
+
+		IOStreams: streams,
+	}
+}
+
+// NewCmdRoot provides a cobra command wrapping Options
+func NewCmdRoot(streams genericclioptions.IOStreams) *cobra.Command {
+	o := NewRootOptions(streams)
+
+	cmd := &cobra.Command{
+		Use: "check-eds [subcommand] [flags]",
+	}
+
+	o.configFlags.AddFlags(cmd.Flags())
+
+	cmd.AddCommand(upgrade.NewCmdUpgrade(streams))
+
+	return cmd
+}
+
+// Complete sets all information required for processing the command
+func (o *Options) Complete(cmd *cobra.Command, args []string) error {
+	return nil
+}
+
+// Root ensures that all required arguments and flag values are provided
+func (o *Options) Root() error {
+	return nil
+}
+
+// Run use to run the command
+func (o *Options) Run() error {
+	return nil
+}

--- a/cmd/check-eds/upgrade/upgrade.go
+++ b/cmd/check-eds/upgrade/upgrade.go
@@ -133,7 +133,7 @@ func (o *Options) Run() error {
 		if err != nil && errors.IsNotFound(err) {
 			return false, fmt.Errorf("ExtendedDaemonSet %s/%s not found", o.userNamespace, o.userExtendedDaemonSetName)
 		} else if err != nil {
-			return false, fmt.Errorf("unable to get ExtendedDaemonSet, err: %v", err)
+			return false, fmt.Errorf("unable to get ExtendedDaemonSet, err: %w", err)
 		}
 
 		if eds.Status.Canary != nil {

--- a/cmd/check-eds/upgrade/upgrade.go
+++ b/cmd/check-eds/upgrade/upgrade.go
@@ -1,0 +1,158 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2019 Datadog, Inc.
+
+package upgrade
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	"github.com/spf13/cobra"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+
+	"github.com/DataDog/extendeddaemonset/api/v1alpha1"
+	"github.com/DataDog/extendeddaemonset/pkg/plugin"
+)
+
+var (
+	upgradeExample = `
+	# wait until the end of the extendeddaemonset foo upgrade
+	%[1]s upgrade foo
+`
+)
+
+// Options provides information required to manage Kanary
+type Options struct {
+	configFlags *genericclioptions.ConfigFlags
+	args        []string
+
+	client client.Client
+
+	genericclioptions.IOStreams
+
+	userNamespace             string
+	userExtendedDaemonSetName string
+	checkPeriod               time.Duration
+	checkTimeout              time.Duration
+}
+
+// NewOptions provides an instance of Options with default values
+func NewOptions(streams genericclioptions.IOStreams) *Options {
+	return &Options{
+		configFlags: genericclioptions.NewConfigFlags(false),
+
+		IOStreams:    streams,
+		checkPeriod:  10 * time.Second,
+		checkTimeout: 2 * time.Hour,
+	}
+}
+
+// NewCmdUpgrade provides a cobra command wrapping Options
+func NewCmdUpgrade(streams genericclioptions.IOStreams) *cobra.Command {
+	o := NewOptions(streams)
+
+	cmd := &cobra.Command{
+		Use:          "upgrade [ExtendedDaemonSet name]",
+		Short:        "wait until end of an ExtendedDaemonSet upgrade",
+		Example:      fmt.Sprintf(upgradeExample, "kubectl"),
+		SilenceUsage: true,
+		RunE: func(c *cobra.Command, args []string) error {
+			if err := o.Complete(c, args); err != nil {
+				return err
+			}
+			if err := o.Validate(); err != nil {
+				return err
+			}
+			return o.Run()
+		},
+	}
+
+	o.configFlags.AddFlags(cmd.Flags())
+
+	return cmd
+}
+
+// Complete sets all information required for processing the command
+func (o *Options) Complete(cmd *cobra.Command, args []string) error {
+	o.args = args
+	var err error
+
+	clientConfig := o.configFlags.ToRawKubeConfigLoader()
+	// Create the Client for Read/Write operations.
+	o.client, err = plugin.NewClient(clientConfig)
+	if err != nil {
+		return fmt.Errorf("unable to instantiate client, err: %v", err)
+	}
+
+	o.userNamespace, _, err = clientConfig.Namespace()
+	if err != nil {
+		return err
+	}
+
+	ns, err2 := cmd.Flags().GetString("namespace")
+	if err2 != nil {
+		return err
+	}
+	if ns != "" {
+		o.userNamespace = ns
+	}
+
+	if len(args) > 0 {
+		o.userExtendedDaemonSetName = args[0]
+	}
+
+	return nil
+}
+
+// Validate ensures that all required arguments and flag values are provided
+func (o *Options) Validate() error {
+
+	if o.userExtendedDaemonSetName == "" {
+		return fmt.Errorf("the ExtendedDaemonset name needs to be provided")
+	}
+
+	return nil
+}
+
+// Run use to run the command
+func (o *Options) Run() error {
+	o.printOut("start checking deployment state")
+
+	checkUpgradeDown := func() (bool, error) {
+		eds := &v1alpha1.ExtendedDaemonSet{}
+		err := o.client.Get(context.TODO(), client.ObjectKey{Namespace: o.userNamespace, Name: o.userExtendedDaemonSetName}, eds)
+		if err != nil && errors.IsNotFound(err) {
+			return false, fmt.Errorf("ExtendedDaemonSet %s/%s not found", o.userNamespace, o.userExtendedDaemonSetName)
+		} else if err != nil {
+			return false, fmt.Errorf("unable to get ExtendedDaemonSet, err: %v", err)
+		}
+
+		if eds.Status.Canary != nil {
+			o.printOut("canary running")
+			return false, nil
+		}
+		if eds.Status.UpToDate < eds.Status.Current {
+			o.printOut("still upgrading nb pods: %d, nb updated pods: %d", eds.Status.Current, eds.Status.UpToDate)
+			return false, nil
+		}
+		o.printOut("upgrade is now finished")
+		return true, nil
+	}
+
+	return wait.Poll(o.checkPeriod, o.checkTimeout, checkUpgradeDown)
+}
+
+func (o *Options) printOut(format string, a ...interface{}) {
+	args := []interface{}{time.Now().UTC().Format("2006-01-02T15:04:05.999Z"), o.userNamespace, o.userExtendedDaemonSetName}
+	args = append(args, a...)
+	_, _ = fmt.Fprintf(o.Out, "[%s] ExtendedDaemonset '%s/%s': "+format+"\n", args...)
+}

--- a/pkg/plugin/fail.go
+++ b/pkg/plugin/fail.go
@@ -154,7 +154,7 @@ func (o *FailOptions) Run() error {
 	if err != nil && errors.IsNotFound(err) {
 		return fmt.Errorf("ExtendedDaemonSet %s/%s not found", o.userNamespace, o.userExtendedDaemonSetName)
 	} else if err != nil {
-		return fmt.Errorf("unable to get ExtendedDaemonSet, err: %v", err)
+		return fmt.Errorf("unable to get ExtendedDaemonSet, err: %w", err)
 	}
 
 	if eds.Spec.Strategy.Canary == nil {

--- a/pkg/plugin/get.go
+++ b/pkg/plugin/get.go
@@ -136,7 +136,7 @@ func (o *GetOptions) Run() error {
 		if err != nil && errors.IsNotFound(err) {
 			return fmt.Errorf("ExtendedDaemonSet %s/%s not found", o.userNamespace, o.userExtendedDaemonSetName)
 		} else if err != nil {
-			return fmt.Errorf("unable to get ExtendedDaemonSet, err: %v", err)
+			return fmt.Errorf("unable to get ExtendedDaemonSet, err: %w", err)
 		}
 		edsList.Items = append(edsList.Items, *eds)
 	}

--- a/pkg/plugin/pause.go
+++ b/pkg/plugin/pause.go
@@ -156,7 +156,7 @@ func (o *PauseOptions) Run() error {
 	if err != nil && errors.IsNotFound(err) {
 		return fmt.Errorf("ExtendedDaemonSet %s/%s not found", o.userNamespace, o.userExtendedDaemonSetName)
 	} else if err != nil {
-		return fmt.Errorf("unable to get ExtendedDaemonSet, err: %v", err)
+		return fmt.Errorf("unable to get ExtendedDaemonSet, err: %w", err)
 	}
 
 	if eds.Spec.Strategy.Canary == nil {

--- a/pkg/plugin/validate.go
+++ b/pkg/plugin/validate.go
@@ -124,7 +124,7 @@ func (o *ValidateOptions) Run() error {
 	if err != nil && errors.IsNotFound(err) {
 		return fmt.Errorf("ExtendedDaemonSet %s/%s not found", o.userNamespace, o.userExtendedDaemonSetName)
 	} else if err != nil {
-		return fmt.Errorf("unable to get ExtendedDaemonSet, err: %v", err)
+		return fmt.Errorf("unable to get ExtendedDaemonSet, err: %w", err)
 	}
 
 	if eds.Status.Canary == nil {


### PR DESCRIPTION
### What does this PR do?

Add extendeddaemonset-check helper

* add new cmd binary `check-eds` which can check when a EDS update is finished.
* add new `app-example` chart: example of an application using the `ExtendedDaemonset`.
* update ci to deliver the `datadog/extendeddaemonset-check` container image.

### Motivation

Helm3 is not able to know when the deployment of an application deployed with an`ExtendedDaemonset` is done.
The new `datadog/extendeddaemonset-check` can be used as helm3 test.

### Additional Notes

N/A

### Describe your test plan

To test it, please follow the instruction in the `charts/app-example/README.md`
