### PR TITLE
Add canary paused / failed metrics

### DIFF
--- a/controllers/extendeddaemonset/metrics.go
+++ b/controllers/extendeddaemonset/metrics.go
@@ -25,6 +25,7 @@ const (
 	extendeddaemonsetStatusIgnoredUnresponsiveNodes = "eds_status_ignored_unresponsive_nodes"
 	extendeddaemonsetStatusCanaryActivated          = "eds_status_canary_activated"
 	extendeddaemonsetStatusCanaryNumberOfNodes      = "eds_status_canary_node_number"
+	extendeddaemonsetStatusCanaryPaused             = "eds_status_canary_paused"
 	extendeddaemonsetLabels                         = "eds_labels"
 )
 
@@ -190,7 +191,7 @@ func generateMetricFamilies() []ksmetric.FamilyGenerator {
 		{
 			Name: extendeddaemonsetStatusCanaryActivated,
 			Type: ksmetric.Gauge,
-			Help: "The status of the canary deployement, set to 1 if active, else 0",
+			Help: "The status of the canary deployment, set to 1 if active, else 0",
 			GenerateFunc: func(obj interface{}) *ksmetric.Family {
 				eds := obj.(*datadoghqv1alpha1.ExtendedDaemonSet)
 				labelKeys, labelValues := utils.GetLabelsValues(&eds.ObjectMeta)
@@ -208,6 +209,38 @@ func generateMetricFamilies() []ksmetric.FamilyGenerator {
 							Value:       val,
 							LabelKeys:   Labelkeys,
 							LabelValues: Labelvalues,
+						},
+					},
+				}
+			},
+		},
+		{
+			Name: extendeddaemonsetStatusCanaryPaused,
+			Type: ksmetric.Gauge,
+			Help: "The paused state of the canary deployment, set to 1 if paused, else 0",
+			GenerateFunc: func(obj interface{}) *ksmetric.Family {
+				eds := obj.(*datadoghqv1alpha1.ExtendedDaemonSet)
+				labelKeys, labelValues := utils.GetLabelsValues(&eds.ObjectMeta)
+				val := float64(0)
+
+				if eds.Status.Canary != nil {
+					rs := eds.Status.Canary.ReplicaSet
+					labelKeys = append(labelKeys, "replicaset")
+					labelValues = append(labelValues, rs)
+					paused, reason := IsCanaryDeploymentPaused(eds.Annotations)
+					if paused {
+						val = 1
+						labelKeys = append(labelKeys, "paused_reason")
+						labelValues = append(labelValues, string(reason))
+					}
+				}
+
+				return &ksmetric.Family{
+					Metrics: []*ksmetric.Metric{
+						{
+							Value:       val,
+							LabelKeys:   labelKeys,
+							LabelValues: labelValues,
 						},
 					},
 				}


### PR DESCRIPTION
### What does this PR do?

Adds a new `eds_status_canary_paused` gauge metric to identify canary in paused state along with the reason.
Adds a new `eds_status_canary_failed` gauge metric to identify canary in failed state along with the reason.

### Motivation

Canary metrics

### Describe your test plan

Check the metrics are exported correctly for canaries in active and paused state.
