### PR TITLE
fix canary fail metric

### DIFF
--- a/controllers/extendeddaemonset/metrics.go
+++ b/controllers/extendeddaemonset/metrics.go
@@ -255,14 +255,10 @@ func generateMetricFamilies() []ksmetric.FamilyGenerator {
 				labelKeys, labelValues := utils.GetLabelsValues(&eds.ObjectMeta)
 				val := float64(0)
 
-				if eds.Status.Canary != nil {
-					rs := eds.Status.Canary.ReplicaSet
-					labelKeys = append(labelKeys, "replicaset")
-					labelValues = append(labelValues, rs)
-					if IsCanaryDeploymentFailed(eds.Annotations) {
-						val = 1
-					}
+				if IsCanaryDeploymentFailed(eds.Annotations) {
+					val = 1
 				}
+
 				return &ksmetric.Family{
 					Metrics: []*ksmetric.Metric{
 						{


### PR DESCRIPTION
### What does this PR do?
Follow up to #56

Since we set Status.Canary to nil when the canary deployment fails, this metric will never change.

### Motivation
### Additional Notes
### Describe your test plan
Deploy a canary EDS, and then exec onto the EDS controller pod and check the fail metric from the output of curl localhost:8080/ksmetrics . Fail the canary and check the metric again, and make sure it changed to 1.