### PR TITLE
Fix spec.strategy.ReconcileFrequency defaulting check

### DIFF
--- a/api/v1alpha1/extendeddaemonset_default.go
+++ b/api/v1alpha1/extendeddaemonset_default.go
@@ -29,6 +29,10 @@ func IsDefaultedExtendedDaemonSet(dd *ExtendedDaemonSet) bool {
 		return false
 	}
 
+	if dd.Spec.Strategy.ReconcileFrequency == nil {
+		return false
+	}
+
 	if dd.Spec.Strategy.Canary != nil {
 		if defaulted := IsDefaultedExtendedDaemonSetSpecStrategyCanary(dd.Spec.Strategy.Canary); !defaulted {
 			return false


### PR DESCRIPTION
### What does this PR do?

This PR add a check in `IsDefaultedExtendedDaemonSet()` function to verify that
the `spec.strategy.ReconcileFrequency` is properly defaulted.

### Motivation

the `spec.strategy.ReconcileFrequency` wasn't part of the `IsDefaultedExtendedDaemonSet()`
function that check the `ExtendedDaemonSetSpec` was properly configured.

### Additional Notes

N/A

### Describe your test plan

few steps:

* Create a new ExtendedDaemonset. the `reconcileFrequency` should have been defaulted when 
  the CR is created.
* Edit this ExtendedDaemonset to remove the `reconcileFrequency` from the `spec.strategy`;
  The controller should update the `spec.strategy` to add it back.
* Another test is to set a different `reconcileFrequency` value, to validate that the controller
  Didn't override a value provided by the user.
