### PR TITLE
[e2e] Resurrecting e2e tests on kind with envtest framework

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -12,21 +12,33 @@ jobs:
       with:
         go-version: 1.13
       id: go
-    - name: install requiere packages
+    - name: Install required packages
       uses: mstksg/get-package@v1
       with:
         apt-get: mercurial jq build-essential
     - name: Check out code into the Go module directory
       uses: actions/checkout@v1
-    - name: install tools
+    - name: Install tools
       run: |
         make install-tools
-    - name: run build
+    - name: Run build
       run: |
         make manager
-    - name: run unit tests and E2E tests (fake cluster)
+    - name: Run unit/control plane tests (fake cluster)
       run: |
         make test
+    - name: Setup kind for e2e
+      uses: engineerd/setup-kind@v0.5.0
+      with:
+        version: "v0.9.0"
+        config: test/cluster-kind.yaml
+        name: eds-e2e
+    - name: Run e2e tests (kind cluster)
+      run: |
+        export PATH=$PATH:$(pwd)/bin
+        kubectl cluster-info --context kind-eds-e2e
+        kubectl get pods -n kube-system
+        make e2e
     - uses: codecov/codecov-action@v1
       with:
         token: ${{ secrets.CODECOV_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,12 @@ test: build manifests verify-license gotest
 gotest:
 	go test ./... -coverprofile cover.out
 
+e2e: build manifests verify-license goe2e
+
+# Runs e2e tests (expects a configured cluster)
+goe2e:
+	go test --tags=e2e ./controllers -ginkgo.progress -ginkgo.v -test.v
+
 # Build manager binary
 manager: generate lint
 	go build -ldflags '${LDFLAGS}' -o bin/manager main.go

--- a/controllers/extendeddaemonset_test.go
+++ b/controllers/extendeddaemonset_test.go
@@ -135,7 +135,6 @@ var _ = Describe("ExtendedDaemonSet Controller", func() {
 	})
 
 	Context("Using ExtendedDaemonsetSetting", func() {
-		// var err error
 		name := "eds-setting"
 		key := types.NamespacedName{
 			Namespace: namespace,

--- a/controllers/setup.go
+++ b/controllers/setup.go
@@ -16,7 +16,7 @@ import (
 	"github.com/DataDog/extendeddaemonset/controllers/extendeddaemonsetsetting"
 )
 
-// SetupControllers start all controllers (also used by e2e tests)
+// SetupControllers start all controllers (also used by unit and e2e tests)
 func SetupControllers(mgr manager.Manager, nodeAffinityMatchSupport bool) error {
 	if err := (&ExtendedDaemonSetReconciler{
 		Client:   mgr.GetClient(),

--- a/controllers/suite_helpers_test.go
+++ b/controllers/suite_helpers_test.go
@@ -1,0 +1,49 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2019 Datadog, Inc.
+
+package controllers
+
+import (
+	"context"
+	"fmt"
+
+	. "github.com/onsi/ginkgo"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	datadoghqv1alpha1 "github.com/DataDog/extendeddaemonset/api/v1alpha1"
+)
+
+type condFn func() bool
+
+func withGet(nsName types.NamespacedName, obj runtime.Object, desc string, condition condFn) condFn {
+	return func() bool {
+		err := k8sClient.Get(context.Background(), nsName, obj)
+		if err != nil {
+			fmt.Fprintf(GinkgoWriter, "Failed to get %s [%s/%s]: %v", desc, nsName.Namespace, nsName.Name, err)
+			return false
+		}
+		return condition()
+	}
+}
+func withEDS(nsName types.NamespacedName, eds *datadoghqv1alpha1.ExtendedDaemonSet, condition condFn) condFn {
+	return withGet(nsName, eds, "EDS", condition)
+}
+
+func withERS(nsName types.NamespacedName, ers *datadoghqv1alpha1.ExtendedDaemonSetReplicaSet, condition condFn) condFn {
+	return withGet(nsName, ers, "ERS", condition)
+}
+
+func withList(listOptions []client.ListOption, obj runtime.Object, desc string, condition condFn) condFn {
+	return func() bool {
+		err := k8sClient.List(context.Background(), obj, listOptions...)
+		if err != nil {
+			fmt.Fprintf(GinkgoWriter, "Failed to list %s: %v", desc, err)
+			return false
+		}
+		return condition()
+	}
+}

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -3,8 +3,6 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-2019 Datadog, Inc.
 
-// +build !e2e
-
 package controllers
 
 import (
@@ -16,6 +14,8 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -33,11 +33,23 @@ import (
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to
 // http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
 
-var cfg *rest.Config
-var k8sClient client.Client
-var testEnv *envtest.Environment
+type testConfigOptions struct {
+	useExistingCluster bool
+	crdVersion         string
+	namespace          string
+}
 
-const nodesCount = 2
+const (
+	fakeNodesCount   = 2
+	defaultNamespace = "default"
+)
+
+var (
+	cfg        *rest.Config
+	k8sClient  client.Client
+	testEnv    *envtest.Environment
+	testConfig = initTestConfig()
+)
 
 func TestAPIs(t *testing.T) {
 	RegisterFailHandler(Fail)
@@ -53,7 +65,8 @@ var _ = BeforeSuite(func(done Done) {
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
-		CRDDirectoryPaths: []string{filepath.Join("..", "config", "crd", "bases", "v1")},
+		UseExistingCluster: datadoghqv1alpha1.NewBool(testConfig.useExistingCluster),
+		CRDDirectoryPaths:  []string{filepath.Join("..", "config", "crd", "bases", testConfig.crdVersion)},
 	}
 	// Not present in envtest.Environment
 	err = os.Setenv("KUBEBUILDER_ASSETS", filepath.Join("..", "bin", "kubebuilder"))
@@ -72,10 +85,21 @@ var _ = BeforeSuite(func(done Done) {
 	Expect(err).ToNot(HaveOccurred())
 	Expect(k8sClient).ToNot(BeNil())
 
-	// Create some Nodes
-	for i := 0; i < nodesCount; i++ {
-		nodei := testutils.NewNode(fmt.Sprintf("node%d", i+1), nil)
-		Expect(k8sClient.Create(context.Background(), nodei)).Should(Succeed())
+	if !testConfig.useExistingCluster {
+		// Create some Nodes
+		for i := 0; i < fakeNodesCount; i++ {
+			nodei := testutils.NewNode(fmt.Sprintf("node%d", i+1), nil)
+			Expect(k8sClient.Create(context.Background(), nodei)).Should(Succeed())
+		}
+	}
+
+	if testConfig.namespace != defaultNamespace {
+		ns := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: testConfig.namespace,
+			},
+		}
+		Expect(k8sClient.Create(context.Background(), ns)).Should(Succeed())
 	}
 
 	// Start controllers
@@ -98,6 +122,14 @@ var _ = BeforeSuite(func(done Done) {
 
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
+	if testConfig.namespace != defaultNamespace {
+		ns := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: testConfig.namespace,
+			},
+		}
+		Expect(k8sClient.Delete(context.Background(), ns)).Should(Succeed())
+	}
 	err := testEnv.Stop()
 	Expect(err).ToNot(HaveOccurred())
 })

--- a/controllers/suite_unit_test.go
+++ b/controllers/suite_unit_test.go
@@ -3,19 +3,14 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-2020 Datadog, Inc.
 
-// +build e2e
+// +build !e2e
 
 package controllers
 
-import (
-	"fmt"
-	"time"
-)
-
 func initTestConfig() *testConfigOptions {
 	return &testConfigOptions{
-		useExistingCluster: true,
-		crdVersion:         "v1beta1",
-		namespace:          fmt.Sprintf("eds-%d", time.Now().Unix()),
+		useExistingCluster: false,
+		crdVersion:         "v1",
+		namespace:          defaultNamespace,
 	}
 }

--- a/test/README.md
+++ b/test/README.md
@@ -1,0 +1,18 @@
+# Tests
+
+## Unit-tests
+
+The command: ```make test``` with execute the unit-tests in every package and also generate the code coverage report.
+
+## End to end testing
+
+End to end test suite can be executed with the comment: ```make e2e```.
+
+To test locally, you should use "[Kind](https://kind.sigs.k8s.io/)" for creating a multi nodes local cluster.
+And use the Kind cluster template: `test/cluster-kind.yaml`
+
+```console
+kind create cluster --config test/cluster-kind.yaml
+```
+
+It will spinn up a 3 nodes cluster: 1 control plane + 2 worker nodes.

--- a/test/cluster-kind.yaml
+++ b/test/cluster-kind.yaml
@@ -1,0 +1,7 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+name: eds-e2e
+nodes:
+- role: control-plane
+- role: worker
+- role: worker


### PR DESCRIPTION
### What does this PR do?

- Added initial tests for testing autoPause and autoFail of canary on pod restarts.

### Motivation

- While envtest control plane tests are great they don't allow us to exercise scenarios that assert on behaviors involving failure cases such as pod restarts.

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details you may have to test your PR.
