### PR TITLE
use client.Patch() for [add|remov]ing canary label

### DIFF
--- a/controllers/extendeddaemonsetreplicaset/strategy/utils.go
+++ b/controllers/extendeddaemonsetreplicaset/strategy/utils.go
@@ -206,8 +206,14 @@ func addPodLabel(c client.Client, pod *corev1.Pod, k, v string) error {
 		// The label is there, nothing to do
 		return nil
 	}
+
+	// A merge patch will preserve other fields modified at runtime.
+	patch := client.MergeFrom(pod.DeepCopy())
+	if pod.Labels == nil {
+		pod.Labels = make(map[string]string)
+	}
 	pod.Labels[k] = v
-	return c.Update(context.TODO(), pod)
+	return c.Patch(context.TODO(), pod, patch)
 }
 
 // deletePodLabel deletes a given pod label, no-op if the pod is nil or if the label doesn't exists
@@ -225,6 +231,9 @@ func deletePodLabel(c client.Client, pod *corev1.Pod, k string) error {
 		// The label is not there, nothing to do
 		return nil
 	}
+
+	// A merge patch will preserve other fields modified at runtime.
+	patch := client.MergeFrom(pod.DeepCopy())
 	delete(pod.Labels, k)
-	return c.Update(context.TODO(), pod)
+	return c.Patch(context.TODO(), pod, patch)
 }

--- a/controllers/extendeddaemonsetreplicaset/strategy/utils.go
+++ b/controllers/extendeddaemonsetreplicaset/strategy/utils.go
@@ -138,7 +138,7 @@ func manageUnscheduledPodNodes(pods []*corev1.Pod) []string {
 }
 
 // annotateCanaryDeploymentWithReason annotates the Canary deployment with a reason
-func annotateCanaryDeploymentWithReason(client client.Client, eds *datadoghqv1alpha1.ExtendedDaemonSet, valueKey string, reasonKey string, reason datadoghqv1alpha1.ExtendedDaemonSetStatusReason) error {
+func annotateCanaryDeploymentWithReason(c client.Client, eds *datadoghqv1alpha1.ExtendedDaemonSet, valueKey string, reasonKey string, reason datadoghqv1alpha1.ExtendedDaemonSetStatusReason) error {
 	newEds := eds.DeepCopy()
 	if newEds.Annotations == nil {
 		newEds.Annotations = make(map[string]string)
@@ -149,13 +149,11 @@ func annotateCanaryDeploymentWithReason(client client.Client, eds *datadoghqv1al
 			return nil
 		}
 	}
+
+	patch := client.MergeFrom(newEds.DeepCopy())
 	newEds.Annotations[valueKey] = valueTrue
 	newEds.Annotations[reasonKey] = string(reason)
-
-	if err := client.Update(context.TODO(), newEds); err != nil {
-		return err
-	}
-	return nil
+	return c.Patch(context.TODO(), newEds, patch)
 }
 
 // pauseCanaryDeployment updates two annotations so that the Canary deployment is marked as paused, along with a reason


### PR DESCRIPTION
### What does this PR do?

Use the `client.Patch()` function instead of `client.Update()` to add canary label on Pods.

### Motivation

Previously the function client.Update() was used to add or remove the canary
labels on the Pods. Using `Patch()` limit possible conflict and decrease message
size.

It removes bug on Kubernetes 1.19.0 when the API-Server return an error with the function `client.Update()`, because the controller is trying to update an immutable `Pod.Spec` field.  

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

* Create a Kubernetes v1.19
* Deploy a EDS with a canary configuration
* Update the EDS.spec.template
* check that canary Pods have the canary labels.
