### PR TITLE
[Plugin] Add canary pods and not ready pods commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,7 +267,22 @@ Available Commands:
   get         get ExtendedDaemonSet deployment(s)
   get-ers     get-ers ExtendedDaemonSetReplicaset deployment(s)
   help        Help about any command
+  pods        print the list pods managed by the EDS
 ```
+
+#### List the not ready pods managed by the ExtendedDaemonSet
+
+`kubectl-eds pods <ExtendedDaemonSet name> --select=not-ready`
+
+#### List the active Canary pods
+
+Print the canary pods and their corresponding status and restart counts.
+
+`kubectl-eds canary pods <ExtendedDaemonSet name>`
+
+OR
+
+`kubectl-eds pods <ExtendedDaemonSet name> --select=canary`
 
 #### Validate Canary deployment
 

--- a/cmd/check-eds/upgrade/upgrade.go
+++ b/cmd/check-eds/upgrade/upgrade.go
@@ -20,7 +20,7 @@ import (
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 
 	"github.com/DataDog/extendeddaemonset/api/v1alpha1"
-	"github.com/DataDog/extendeddaemonset/pkg/plugin"
+	"github.com/DataDog/extendeddaemonset/pkg/plugin/common"
 )
 
 var (
@@ -88,7 +88,7 @@ func (o *Options) Complete(cmd *cobra.Command, args []string) error {
 
 	clientConfig := o.configFlags.ToRawKubeConfigLoader()
 	// Create the Client for Read/Write operations.
-	o.client, err = plugin.NewClient(clientConfig)
+	o.client, err = common.NewClient(clientConfig)
 	if err != nil {
 		return fmt.Errorf("unable to instantiate client, err: %v", err)
 	}

--- a/pkg/plugin/canary/canary.go
+++ b/pkg/plugin/canary/canary.go
@@ -1,4 +1,4 @@
-package plugin
+package canary
 
 import (
 	"github.com/spf13/cobra"
@@ -12,11 +12,12 @@ func NewCmdCanary(streams genericclioptions.IOStreams) *cobra.Command {
 		Short: "control ExtendedDaemonSet canary deployment",
 	}
 
-	cmd.AddCommand(NewCmdValidate(streams))
-	cmd.AddCommand(NewCmdPause(streams))
-	cmd.AddCommand(NewCmdUnpause(streams))
-	cmd.AddCommand(NewCmdFail(streams))
-	cmd.AddCommand(NewCmdReset(streams))
+	cmd.AddCommand(newCmdValidate(streams))
+	cmd.AddCommand(newCmdPause(streams))
+	cmd.AddCommand(newCmdUnpause(streams))
+	cmd.AddCommand(newCmdFail(streams))
+	cmd.AddCommand(newCmdReset(streams))
+	cmd.AddCommand(newCmdPods(streams))
 
 	return cmd
 }

--- a/pkg/plugin/canary/fail.go
+++ b/pkg/plugin/canary/fail.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-2019 Datadog, Inc.
 
-package plugin
+package canary
 
 import (
 	"context"
@@ -16,6 +16,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/DataDog/extendeddaemonset/api/v1alpha1"
+	"github.com/DataDog/extendeddaemonset/pkg/plugin/common"
 )
 
 const (
@@ -30,8 +31,8 @@ var (
 `
 )
 
-// FailOptions provides information required to manage ExtendedDaemonSet
-type FailOptions struct {
+// failOptions provides information required to manage ExtendedDaemonSet
+type failOptions struct {
 	configFlags *genericclioptions.ConfigFlags
 	args        []string
 
@@ -44,9 +45,9 @@ type FailOptions struct {
 	failStatus                bool
 }
 
-// NewFailOptions provides an instance of GetOptions with default values
-func NewFailOptions(streams genericclioptions.IOStreams, failStatus bool) *FailOptions {
-	return &FailOptions{
+// newfailOptions provides an instance of GetOptions with default values
+func newfailOptions(streams genericclioptions.IOStreams, failStatus bool) *failOptions {
+	return &failOptions{
 		configFlags: genericclioptions.NewConfigFlags(false),
 
 		IOStreams: streams,
@@ -55,9 +56,9 @@ func NewFailOptions(streams genericclioptions.IOStreams, failStatus bool) *FailO
 	}
 }
 
-// NewCmdFail provides a cobra command wrapping FailOptions
-func NewCmdFail(streams genericclioptions.IOStreams) *cobra.Command {
-	o := NewFailOptions(streams, cmdFail)
+// newCmdFail provides a cobra command wrapping failOptions
+func newCmdFail(streams genericclioptions.IOStreams) *cobra.Command {
+	o := newfailOptions(streams, cmdFail)
 
 	cmd := &cobra.Command{
 		Use:          "fail [ExtendedDaemonSet name]",
@@ -65,13 +66,13 @@ func NewCmdFail(streams genericclioptions.IOStreams) *cobra.Command {
 		Example:      fmt.Sprintf(failExample, "fail"),
 		SilenceUsage: true,
 		RunE: func(c *cobra.Command, args []string) error {
-			if err := o.Complete(c, args); err != nil {
+			if err := o.complete(c, args); err != nil {
 				return err
 			}
-			if err := o.Validate(); err != nil {
+			if err := o.validate(); err != nil {
 				return err
 			}
-			return o.Run()
+			return o.run()
 		},
 	}
 
@@ -80,9 +81,9 @@ func NewCmdFail(streams genericclioptions.IOStreams) *cobra.Command {
 	return cmd
 }
 
-// NewCmdReset provides a cobra command wrapping FailOptions
-func NewCmdReset(streams genericclioptions.IOStreams) *cobra.Command {
-	o := NewFailOptions(streams, cmdReset)
+// newCmdReset provides a cobra command wrapping failOptions
+func newCmdReset(streams genericclioptions.IOStreams) *cobra.Command {
+	o := newfailOptions(streams, cmdReset)
 
 	cmd := &cobra.Command{
 		Use:          "reset [ExtendedDaemonSet name]",
@@ -90,13 +91,13 @@ func NewCmdReset(streams genericclioptions.IOStreams) *cobra.Command {
 		Example:      fmt.Sprintf(failExample, "reset"),
 		SilenceUsage: true,
 		RunE: func(c *cobra.Command, args []string) error {
-			if err := o.Complete(c, args); err != nil {
+			if err := o.complete(c, args); err != nil {
 				return err
 			}
-			if err := o.Validate(); err != nil {
+			if err := o.validate(); err != nil {
 				return err
 			}
-			return o.Run()
+			return o.run()
 		},
 	}
 
@@ -105,14 +106,14 @@ func NewCmdReset(streams genericclioptions.IOStreams) *cobra.Command {
 	return cmd
 }
 
-// Complete sets all information required for processing the command
-func (o *FailOptions) Complete(cmd *cobra.Command, args []string) error {
+// complete sets all information required for processing the command
+func (o *failOptions) complete(cmd *cobra.Command, args []string) error {
 	o.args = args
 	var err error
 
 	clientConfig := o.configFlags.ToRawKubeConfigLoader()
 	// Create the Client for Read/Write operations.
-	o.client, err = NewClient(clientConfig)
+	o.client, err = common.NewClient(clientConfig)
 	if err != nil {
 		return fmt.Errorf("unable to instantiate client, err: %v", err)
 	}
@@ -137,8 +138,8 @@ func (o *FailOptions) Complete(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-// Validate ensures that all required arguments and flag values are provided
-func (o *FailOptions) Validate() error {
+// validate ensures that all required arguments and flag values are provided
+func (o *failOptions) validate() error {
 
 	if len(o.args) < 1 {
 		return fmt.Errorf("the extendeddaemonset name is required")
@@ -147,8 +148,8 @@ func (o *FailOptions) Validate() error {
 	return nil
 }
 
-// Run use to run the command
-func (o *FailOptions) Run() error {
+// run use to run the command
+func (o *failOptions) run() error {
 	eds := &v1alpha1.ExtendedDaemonSet{}
 	err := o.client.Get(context.TODO(), client.ObjectKey{Namespace: o.userNamespace, Name: o.userExtendedDaemonSetName}, eds)
 	if err != nil && errors.IsNotFound(err) {

--- a/pkg/plugin/canary/pods.go
+++ b/pkg/plugin/canary/pods.go
@@ -1,0 +1,112 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2020 Datadog, Inc.
+
+package canary
+
+import (
+	"fmt"
+
+	"github.com/DataDog/extendeddaemonset/pkg/plugin/common"
+
+	"github.com/spf13/cobra"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var (
+	podsExample = `
+	# list the canary pods
+	%[1]s canary pods foo
+`
+)
+
+// podsOptions provides information required to manage ExtendedDaemonSet
+type podsOptions struct {
+	client client.Client
+	genericclioptions.IOStreams
+	configFlags               *genericclioptions.ConfigFlags
+	args                      []string
+	userNamespace             string
+	userExtendedDaemonSetName string
+}
+
+// newPodsOptions provides an instance of podsOptions with default values
+func newPodsOptions(streams genericclioptions.IOStreams) *podsOptions {
+	return &podsOptions{
+		configFlags: genericclioptions.NewConfigFlags(false),
+		IOStreams:   streams,
+	}
+}
+
+// newCmdPods provides a cobra command wrapping podsOptions
+func newCmdPods(streams genericclioptions.IOStreams) *cobra.Command {
+	o := newPodsOptions(streams)
+
+	cmd := &cobra.Command{
+		Use:          "pods [ExtendedDaemonSet name]",
+		Short:        "print the list of active canary pods",
+		Example:      fmt.Sprintf(podsExample, "kubectl"),
+		SilenceUsage: true,
+		RunE: func(c *cobra.Command, args []string) error {
+			if err := o.complete(c, args); err != nil {
+				return err
+			}
+			if err := o.validate(); err != nil {
+				return err
+			}
+			return o.run()
+		},
+	}
+
+	o.configFlags.AddFlags(cmd.Flags())
+
+	return cmd
+}
+
+// complete sets all information required for processing the command
+func (o *podsOptions) complete(cmd *cobra.Command, args []string) error {
+	o.args = args
+	var err error
+
+	clientConfig := o.configFlags.ToRawKubeConfigLoader()
+	// Create the Client for Read/Write operations.
+	o.client, err = common.NewClient(clientConfig)
+	if err != nil {
+		return fmt.Errorf("unable to instantiate client, err: %v", err)
+	}
+
+	o.userNamespace, _, err = clientConfig.Namespace()
+	if err != nil {
+		return err
+	}
+
+	ns, err2 := cmd.Flags().GetString("namespace")
+	if err2 != nil {
+		return err
+	}
+	if ns != "" {
+		o.userNamespace = ns
+	}
+
+	if len(args) > 0 {
+		o.userExtendedDaemonSetName = args[0]
+	}
+
+	return nil
+}
+
+// validate ensures that all required arguments and flag values are provided
+func (o *podsOptions) validate() error {
+	if len(o.args) < 1 {
+		return fmt.Errorf("the extendeddaemonset name is required")
+	}
+
+	return nil
+}
+
+// run runs the command
+func (o *podsOptions) run() error {
+	return common.PrintCanaryPods(o.client, o.userNamespace, o.userExtendedDaemonSetName, o.Out)
+}

--- a/pkg/plugin/common/client.go
+++ b/pkg/plugin/common/client.go
@@ -3,18 +3,17 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-2019 Datadog, Inc.
 
-package plugin
+package common
 
 import (
 	"fmt"
 
 	"github.com/DataDog/extendeddaemonset/api/v1alpha1"
-	"k8s.io/client-go/tools/clientcmd"
-
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 
 	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/clientcmd"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 )
 
 // NewClient returns new client instance

--- a/pkg/plugin/common/pods.go
+++ b/pkg/plugin/common/pods.go
@@ -1,0 +1,83 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2020 Datadog, Inc.
+
+package common
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/DataDog/extendeddaemonset/api/v1alpha1"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// PrintCanaryPods prints the list of canary pods
+func PrintCanaryPods(c client.Client, ns, edsName string, out io.Writer) error {
+	eds := &v1alpha1.ExtendedDaemonSet{}
+	err := c.Get(context.TODO(), client.ObjectKey{Namespace: ns, Name: edsName}, eds)
+	if err != nil && errors.IsNotFound(err) {
+		return fmt.Errorf("ExtendedDaemonSet %s/%s not found", ns, edsName)
+	} else if err != nil {
+		return fmt.Errorf("unable to get ExtendedDaemonSet, err: %w", err)
+	}
+
+	if eds.Status.Canary == nil {
+		return fmt.Errorf("the ExtendedDaemonset is not currently running a canary replicaset")
+	}
+
+	req, err := labels.NewRequirement(v1alpha1.ExtendedDaemonSetReplicaSetNameLabelKey, selection.Equals, []string{eds.Status.Canary.ReplicaSet})
+	if err != nil {
+		return fmt.Errorf("couldn't query canary pods: %w", err)
+	}
+
+	rsSelector := labels.NewSelector().Add(*req)
+	return printPods(c, rsSelector, out, false)
+}
+
+// PrintNotReadyPods prints the list of not ready pods
+func PrintNotReadyPods(c client.Client, ns, edsName string, out io.Writer) error {
+	eds := &v1alpha1.ExtendedDaemonSet{}
+	err := c.Get(context.TODO(), client.ObjectKey{Namespace: ns, Name: edsName}, eds)
+	if err != nil && errors.IsNotFound(err) {
+		return fmt.Errorf("ExtendedDaemonSet %s/%s not found", ns, edsName)
+	} else if err != nil {
+		return fmt.Errorf("unable to get ExtendedDaemonSet, err: %w", err)
+	}
+
+	req, err := labels.NewRequirement(v1alpha1.ExtendedDaemonSetNameLabelKey, selection.Equals, []string{edsName})
+	if err != nil {
+		return fmt.Errorf("couldn't query daemon pods: %w", err)
+	}
+
+	edsSelector := labels.NewSelector().Add(*req)
+	return printPods(c, edsSelector, out, true)
+}
+
+func printPods(c client.Client, selector labels.Selector, out io.Writer, notReadyOnly bool) error {
+	podList := &corev1.PodList{}
+	err := c.List(context.TODO(), podList, &client.ListOptions{LabelSelector: selector})
+	if err != nil {
+		return fmt.Errorf("couldn't get pods: %w", err)
+	}
+
+	table := newPodsTable(out)
+	for _, pod := range podList.Items {
+		podNotready, reason := isPodNotReady(&pod)
+		if notReadyOnly && !podNotready {
+			continue
+		}
+		ready, containers, restarts := containersInfo(&pod)
+		table.Append([]string{pod.Name, ready, string(pod.Status.Phase), reason, containers, restarts, pod.Spec.NodeName, getNodeReadiness(c, pod.Spec.NodeName)})
+	}
+
+	table.Render()
+	return nil
+}

--- a/pkg/plugin/common/table.go
+++ b/pkg/plugin/common/table.go
@@ -1,0 +1,28 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2020 Datadog, Inc.
+
+package common
+
+import (
+	"io"
+
+	"github.com/olekukonko/tablewriter"
+)
+
+// newPodsTable returns a table to print pods
+func newPodsTable(out io.Writer) *tablewriter.Table {
+	table := tablewriter.NewWriter(out)
+	table.SetHeader([]string{"Pod", "Ready", "Phase", "Reason", "Not ready containers", "Restarts", "Node", "Node Ready"})
+	table.SetBorders(tablewriter.Border{Left: false, Top: false, Right: false, Bottom: false})
+	table.SetHeaderAlignment(tablewriter.ALIGN_LEFT)
+	table.SetRowLine(false)
+	table.SetCenterSeparator("")
+	table.SetColumnSeparator("")
+	table.SetRowSeparator("")
+	table.SetAlignment(tablewriter.ALIGN_LEFT)
+	table.SetHeaderLine(false)
+
+	return table
+}

--- a/pkg/plugin/common/utils.go
+++ b/pkg/plugin/common/utils.go
@@ -1,0 +1,72 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2020 Datadog, Inc.
+
+package common
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// IntToString converts int32 into string
+func IntToString(i int32) string {
+	return fmt.Sprintf("%d", i)
+}
+
+// isPodNotReady returns whether the pod is ready, returns the the reason if not ready
+func isPodNotReady(pod *corev1.Pod) (bool, string) {
+	if pod.Status.Phase != corev1.PodRunning {
+		return true, pod.Status.Reason
+	}
+
+	for _, cond := range pod.Status.Conditions {
+		if cond.Type == corev1.PodReady && cond.Status != corev1.ConditionTrue {
+			return true, cond.Reason
+		}
+	}
+
+	return false, ""
+}
+
+// containersInfo returns containers readiness and restart details
+func containersInfo(pod *corev1.Pod) (string, string, string) {
+	notreadyContainers := []string{}
+	containersCount := len(pod.Status.ContainerStatuses)
+	notreadyCount := 0
+	restartCount := int32(0)
+	for _, ctr := range pod.Status.ContainerStatuses {
+		restartCount += ctr.RestartCount
+		if !ctr.Ready {
+			notreadyCount++
+			notreadyContainers = append(notreadyContainers, ctr.Name)
+		}
+	}
+	return fmt.Sprintf("%d/%d", containersCount-notreadyCount, containersCount), strings.Join(notreadyContainers, ", "), IntToString(restartCount)
+}
+
+// getNodeReadiness returns whether a node is ready
+func getNodeReadiness(c client.Client, nodename string) string {
+	var isNodeReady = func(node *corev1.Node) bool {
+		for _, cond := range node.Status.Conditions {
+			if cond.Type == corev1.NodeReady && cond.Status == corev1.ConditionTrue {
+				return true
+			}
+		}
+		return false
+	}
+
+	node := &corev1.Node{}
+	readiness := "Unknown"
+	if err := c.Get(context.TODO(), client.ObjectKey{Name: nodename}, node); err == nil {
+		readiness = strconv.FormatBool(isNodeReady(node))
+	}
+
+	return readiness
+}

--- a/pkg/plugin/common/utils_test.go
+++ b/pkg/plugin/common/utils_test.go
@@ -1,0 +1,158 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2020 Datadog, Inc.
+
+package common
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestIsPodNotReady(t *testing.T) {
+	tests := []struct {
+		name     string
+		pod      *corev1.Pod
+		notready bool
+		reason   string
+	}{
+		{
+			name: "ready",
+			pod: &corev1.Pod{
+				Status: corev1.PodStatus{
+					Phase: corev1.PodRunning,
+					Conditions: []corev1.PodCondition{
+						{Type: corev1.PodReady, Status: corev1.ConditionTrue},
+					},
+				},
+			},
+			notready: false,
+			reason:   "",
+		},
+		{
+			name: "pending",
+			pod: &corev1.Pod{
+				Status: corev1.PodStatus{
+					Phase: corev1.PodPending,
+				},
+			},
+			notready: true,
+			reason:   "",
+		},
+		{
+			name: "evicted",
+			pod: &corev1.Pod{
+				Status: corev1.PodStatus{
+					Phase:  corev1.PodFailed,
+					Reason: "Evicted",
+				},
+			},
+			notready: true,
+			reason:   "Evicted",
+		},
+		{
+			name: "container CLB",
+			pod: &corev1.Pod{
+				Status: corev1.PodStatus{
+					Phase: corev1.PodRunning,
+					Conditions: []corev1.PodCondition{
+						{Type: corev1.PodReady, Status: corev1.ConditionFalse, Reason: "ContainersNotReady"},
+					},
+				},
+			},
+			notready: true,
+			reason:   "ContainersNotReady",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			notready, reason := isPodNotReady(tt.pod)
+			assert.Equal(t, notready, tt.notready)
+			assert.Equal(t, reason, tt.reason)
+		})
+	}
+}
+
+func TestContainersInfo(t *testing.T) {
+	tests := []struct {
+		name       string
+		pod        *corev1.Pod
+		ready      string
+		containers string
+		restarts   string
+	}{
+		{
+			name: "one ready container",
+			pod: &corev1.Pod{
+				Status: corev1.PodStatus{
+					Phase: corev1.PodRunning,
+					ContainerStatuses: []corev1.ContainerStatus{
+						{Name: "foo", RestartCount: 0, Ready: true},
+					},
+				},
+			},
+			ready:      "1/1",
+			containers: "",
+			restarts:   "0",
+		},
+		{
+			name: "multi containers with restarts, all ready",
+			pod: &corev1.Pod{
+				Status: corev1.PodStatus{
+					Phase: corev1.PodRunning,
+					ContainerStatuses: []corev1.ContainerStatus{
+						{Name: "foo", RestartCount: 1, Ready: true},
+						{Name: "bar", RestartCount: 2, Ready: true},
+						{Name: "baz", RestartCount: 3, Ready: true},
+					},
+				},
+			},
+			ready:      "3/3",
+			containers: "",
+			restarts:   "6",
+		},
+		{
+			name: "multi containers with restarts, with notready containers",
+			pod: &corev1.Pod{
+				Status: corev1.PodStatus{
+					Phase: corev1.PodRunning,
+					ContainerStatuses: []corev1.ContainerStatus{
+						{Name: "foo", RestartCount: 1, Ready: true},
+						{Name: "bar", RestartCount: 2, Ready: false},
+						{Name: "baz", RestartCount: 3, Ready: true},
+					},
+				},
+			},
+			ready:      "2/3",
+			containers: "bar",
+			restarts:   "6",
+		},
+		{
+			name: "multi containers with restarts, all containers notready",
+			pod: &corev1.Pod{
+				Status: corev1.PodStatus{
+					Phase: corev1.PodRunning,
+					ContainerStatuses: []corev1.ContainerStatus{
+						{Name: "foo", RestartCount: 1, Ready: false},
+						{Name: "bar", RestartCount: 2, Ready: false},
+						{Name: "baz", RestartCount: 3, Ready: false},
+					},
+				},
+			},
+			ready:      "0/3",
+			containers: "foo, bar, baz",
+			restarts:   "6",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ready, containers, restarts := containersInfo(tt.pod)
+			assert.Equal(t, ready, tt.ready)
+			assert.Equal(t, containers, tt.containers)
+			assert.Equal(t, restarts, tt.restarts)
+		})
+	}
+}

--- a/pkg/plugin/extendeddaemonset.go
+++ b/pkg/plugin/extendeddaemonset.go
@@ -6,8 +6,11 @@
 package plugin
 
 import (
-	"github.com/spf13/cobra"
+	"github.com/DataDog/extendeddaemonset/pkg/plugin/canary"
+	"github.com/DataDog/extendeddaemonset/pkg/plugin/get"
+	"github.com/DataDog/extendeddaemonset/pkg/plugin/pods"
 
+	"github.com/spf13/cobra"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 )
 
@@ -34,9 +37,10 @@ func NewCmdExtendedDaemonset(streams genericclioptions.IOStreams) *cobra.Command
 		Use: "ExtendedDaemonset [subcommand] [flags]",
 	}
 
-	cmd.AddCommand(NewCmdCanary(streams))
-	cmd.AddCommand(NewCmdGet(streams))
-	cmd.AddCommand(NewCmdGetERS(streams))
+	cmd.AddCommand(canary.NewCmdCanary(streams))
+	cmd.AddCommand(get.NewCmdGet(streams))
+	cmd.AddCommand(get.NewCmdGetERS(streams))
+	cmd.AddCommand(pods.NewCmdPods(streams))
 
 	o.configFlags.AddFlags(cmd.Flags())
 

--- a/pkg/plugin/get/common.go
+++ b/pkg/plugin/get/common.go
@@ -3,10 +3,9 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-2019 Datadog, Inc.
 
-package plugin
+package get
 
 import (
-	"fmt"
 	"time"
 
 	"github.com/hako/durafmt"
@@ -14,10 +13,6 @@ import (
 
 	"github.com/DataDog/extendeddaemonset/api/v1alpha1"
 )
-
-func intToString(i int32) string {
-	return fmt.Sprintf("%d", i)
-}
 
 func getCanaryRS(eds *v1alpha1.ExtendedDaemonSet) string {
 	if eds.Status.Canary != nil {

--- a/pkg/plugin/pods/pods.go
+++ b/pkg/plugin/pods/pods.go
@@ -1,0 +1,141 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2020 Datadog, Inc.
+
+package pods
+
+import (
+	"fmt"
+
+	"github.com/DataDog/extendeddaemonset/pkg/plugin/common"
+
+	"github.com/spf13/cobra"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var (
+	podsExample = `
+	# list the not ready pods managed by the EDS foo
+	%[1]s pods --select not-ready foo
+
+	# list the canary pods managed by the EDS foo
+	%[1]s pods --select canary foo
+`
+	selectOpt string
+)
+
+const (
+	canary   = "canary"
+	notReady = "not-ready"
+)
+
+// podsOptions provides information required to manage ExtendedDaemonSet
+type podsOptions struct {
+	client client.Client
+	genericclioptions.IOStreams
+	configFlags               *genericclioptions.ConfigFlags
+	args                      []string
+	userNamespace             string
+	userExtendedDaemonSetName string
+}
+
+// newpodsOptions provides an instance of podsOptions with default values
+func newPodsOptions(streams genericclioptions.IOStreams) *podsOptions {
+	return &podsOptions{
+		configFlags: genericclioptions.NewConfigFlags(false),
+		IOStreams:   streams,
+	}
+}
+
+// NewCmdPods provides a cobra command wrapping podsOptions
+func NewCmdPods(streams genericclioptions.IOStreams) *cobra.Command {
+	o := newPodsOptions(streams)
+
+	cmd := &cobra.Command{
+		Use:          "pods [flags] [ExtendedDaemonSet name]",
+		Short:        "print the list pods managed by the EDS",
+		Example:      fmt.Sprintf(podsExample, "kubectl"),
+		SilenceUsage: true,
+		RunE: func(c *cobra.Command, args []string) error {
+			if err := o.complete(c, args); err != nil {
+				return err
+			}
+			if err := o.validate(); err != nil {
+				return err
+			}
+			return o.run()
+		},
+	}
+
+	cmd.Flags().StringVarP(&selectOpt, "select", "", "", "Select the pods to show (can be either canary or not-ready)")
+	o.configFlags.AddFlags(cmd.Flags())
+
+	return cmd
+}
+
+// complete sets all information required for processing the command
+func (o *podsOptions) complete(cmd *cobra.Command, args []string) error {
+	o.args = args
+	var err error
+
+	clientConfig := o.configFlags.ToRawKubeConfigLoader()
+	// Create the Client for Read/Write operations.
+	o.client, err = common.NewClient(clientConfig)
+	if err != nil {
+		return fmt.Errorf("unable to instantiate client, err: %v", err)
+	}
+
+	o.userNamespace, _, err = clientConfig.Namespace()
+	if err != nil {
+		return err
+	}
+
+	ns, err2 := cmd.Flags().GetString("namespace")
+	if err2 != nil {
+		return err
+	}
+	if ns != "" {
+		o.userNamespace = ns
+	}
+
+	if len(args) > 0 {
+		o.userExtendedDaemonSetName = args[0]
+	}
+
+	return nil
+}
+
+// validate ensures that all required arguments and flag values are provided
+func (o *podsOptions) validate() error {
+	if len(o.args) < 1 {
+		return fmt.Errorf("the extendeddaemonset name is required")
+	}
+
+	if selectOpt == "" {
+		return fmt.Errorf("missing --select flag")
+	}
+
+	if selectOpt != canary && selectOpt != notReady {
+		return invalidSelectErr(selectOpt)
+	}
+
+	return nil
+}
+
+// run runs the command
+func (o *podsOptions) run() error {
+	switch selectOpt {
+	case canary:
+		return common.PrintCanaryPods(o.client, o.userNamespace, o.userExtendedDaemonSetName, o.Out)
+	case notReady:
+		return common.PrintNotReadyPods(o.client, o.userNamespace, o.userExtendedDaemonSetName, o.Out)
+	default:
+		return invalidSelectErr(selectOpt)
+	}
+}
+
+func invalidSelectErr(opt string) error {
+	return fmt.Errorf("invalid select flag value '%s': the supported select values are: 'canary' 'not-ready'", opt)
+}


### PR DESCRIPTION
### What does this PR do?

- `kubectl-eds pods <ExtendedDaemonSet name> --select=not-ready`
- `kubectl-eds pods <ExtendedDaemonSet name> --select=canary`
- `kubectl-eds canary pods <ExtendedDaemonSet name>`

### Motivation

- Identify not ready pods easily
- Identify canary pods easily

### Additional Notes

- `kubectl-eds pods <ExtendedDaemonSet name> --select=canary`
- `kubectl-eds canary pods <ExtendedDaemonSet name>`

```
  POD                           READY  PHASE    REASON  UNREADY CONTAINERS  RESTARTS  NODE                                  NODE READY
  pause-containers-xxxxx-xxxxx  1/1    Running                              0         xxx-xxxxx-xxxxxxxx-xxxx-xxxxxxx-xxxx  true
  pause-containers-xxxxx-xxxxx  1/1    Running                              0         xxx-xxxxx-xxxxxxxx-xxxx-xxxxxxx-xxxx  true
```


- `kubectl-eds pods <ExtendedDaemonSet name> --select=not-ready`

```
  POD                        READY  PHASE    REASON              NOT READY CONTAINERS              RESTARTS  NODE                            NODE READY
  datadog-agent-xxxxx-xxxxx  0/5    Running  ContainersNotReady  agent, process-agent,           901       ip-xx-xxx-xxx-xxx.xxx.internal  true
  datadog-agent-xxxxx-xxxxx  3/5    Running  ContainersNotReady  agent, process-agent            72        ip-xx-xxx-xxx-xx.xxx.internal   false
  datadog-agent-xxxxx-xxxxx  0/5    Pending                      agent, process-agent,           0         ip-xx-xxx-xxx-xx.xxx.internal   false
                                                                 security-agent, system-probe,
                                                                 trace-agent
  datadog-agent-xxxxx-xxxxx  0/0    Failed   OutOfmemory                                         0         ip-xx-xxx-xxx-xx.xxx.internal   true
  datadog-agent-xxxxx-xxxxx  0/0    Failed   Evicted                                             0         ip-xx-xxx-xxx-xxx.xxx.internal  true
```

### Describe your test plan

Compare the command outputs to `k get pods` and `k get nodes`