### PR TITLE
[Fix] Make sure the ERS only handles defaulted EDS CR

### DIFF
--- a/api/v1alpha1/extendeddaemonset_default.go
+++ b/api/v1alpha1/extendeddaemonset_default.go
@@ -32,10 +32,6 @@ func IsDefaultedExtendedDaemonSet(dd *ExtendedDaemonSet) bool {
 		return false
 	}
 
-	if dd.Spec.Strategy.ReconcileFrequency == nil {
-		return false
-	}
-
 	if dd.Spec.Strategy.Canary != nil {
 		if defaulted := IsDefaultedExtendedDaemonSetSpecStrategyCanary(dd.Spec.Strategy.Canary); !defaulted {
 			return false

--- a/controllers/extendeddaemonsetreplicaset/controller.go
+++ b/controllers/extendeddaemonsetreplicaset/controller.go
@@ -80,6 +80,11 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		return reconcile.Result{}, err
 	}
 
+	if !datadoghqv1alpha1.IsDefaultedExtendedDaemonSet(daemonsetInstance) {
+		reqLogger.Info("Parent ExtendedDaemonSet is not defaulted, requeuing")
+		return reconcile.Result{RequeueAfter: time.Second}, nil
+	}
+
 	lastResyncTimeStampCond := conditions.GetExtendedDaemonSetReplicaSetStatusCondition(&replicaSetInstance.Status, datadoghqv1alpha1.ConditionTypeLastFullSync)
 	if lastResyncTimeStampCond != nil {
 		nextSyncTS := lastResyncTimeStampCond.LastUpdateTime.Add(daemonsetInstance.Spec.Strategy.ReconcileFrequency.Duration)

--- a/controllers/extendeddaemonsetreplicaset/controller_test.go
+++ b/controllers/extendeddaemonsetreplicaset/controller_test.go
@@ -120,7 +120,7 @@ func TestReconcileExtendedDaemonSetReplicaSet_Reconcile(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "ReplicaSet, Daemonset exist, but no status Daemonset => should requeue in 1sec",
+			name: "ReplicaSet, Daemonset exists but not defaulted => should requeue in 1sec",
 			fields: fields{
 				client:   fake.NewFakeClient(daemonset, replicaset),
 				scheme:   s,
@@ -133,9 +133,22 @@ func TestReconcileExtendedDaemonSetReplicaSet_Reconcile(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "ReplicaSet, Daemonset exist with status",
+			name: "ReplicaSet, Daemonset exists, defaulted but without a status => should requeue in 1sec",
 			fields: fields{
-				client:   fake.NewFakeClient(daemonsetWithStatus, replicaset),
+				client:   fake.NewFakeClient(datadoghqv1alpha1.DefaultExtendedDaemonSet(daemonset), replicaset),
+				scheme:   s,
+				recorder: recorder,
+			},
+			args: args{
+				request: newRequest("but", "foo-1"),
+			},
+			want:    reconcile.Result{RequeueAfter: time.Second},
+			wantErr: false,
+		},
+		{
+			name: "ReplicaSet, Daemonset exists, defaulted and with a status",
+			fields: fields{
+				client:   fake.NewFakeClient(datadoghqv1alpha1.DefaultExtendedDaemonSet(daemonsetWithStatus), replicaset),
 				scheme:   s,
 				recorder: recorder,
 			},


### PR DESCRIPTION
### What does this PR do?

- Make the ERS controller requeue the request if the CR is not defaulted (yet) by the EDS controller

### Motivation

By design, the ERS controller can receive requests before the EDS controller defaults the CR.

This PR adds safeguard against nil pointers when accessing CR fields (e.g `Spec.Strategy.ReconcileFrequency.Duration`) in the ERS controller.

### Additional Notes

Related to https://github.com/DataDog/extendeddaemonset/pull/65

### Describe your test plan

Same as https://github.com/DataDog/extendeddaemonset/pull/65

- Create a new ExtendedDaemonset. The reconcileFrequency should have been defaulted when
the CR is created.
- Edit this ExtendedDaemonset and remove the reconcileFrequency from the spec.strategy;
The controller should update the spec.strategy to add it back.
- Another test is to set a different reconcileFrequency value, to validate that the controller
Didn't override a value provided by the user.
