### PR TITLE
Fix IsPodAvailable() to wait the PodReady is true

### DIFF
--- a/controllers/extendeddaemonsetreplicaset/strategy/canary_test.go
+++ b/controllers/extendeddaemonsetreplicaset/strategy/canary_test.go
@@ -356,7 +356,7 @@ func TestManageCanaryStatus_HighRestartsLeadingToPause(t *testing.T) {
 				Desired:   3,
 				Current:   1,
 				Ready:     0,
-				Available: 1,
+				Available: 0,
 				Conditions: []v1alpha1.ExtendedDaemonSetReplicaSetCondition{
 					{
 						Type:               v1alpha1.ConditionTypePodRestarting,
@@ -414,7 +414,7 @@ func TestManageCanaryStatus_HighRestartsLeadingToFail(t *testing.T) {
 				Desired:   3,
 				Current:   1,
 				Ready:     0,
-				Available: 1,
+				Available: 0,
 				Conditions: []v1alpha1.ExtendedDaemonSetReplicaSetCondition{
 					{
 						Type:               v1alpha1.ConditionTypePodRestarting,
@@ -486,7 +486,7 @@ func TestManageCanaryStatus_LongRestartsDurationLeadingToFail(t *testing.T) {
 				Desired:   3,
 				Current:   1,
 				Ready:     0,
-				Available: 1,
+				Available: 0,
 				Conditions: []v1alpha1.ExtendedDaemonSetReplicaSetCondition{
 					{
 						Type:               v1alpha1.ConditionTypePodRestarting,
@@ -543,7 +543,7 @@ func TestManageCanaryStatus_ImagePullErrorLeadingToPause(t *testing.T) {
 				Desired:   3,
 				Current:   1,
 				Ready:     0,
-				Available: 1,
+				Available: 0,
 				Conditions: []v1alpha1.ExtendedDaemonSetReplicaSetCondition{
 					{
 						Type:               v1alpha1.ConditionTypePodCannotStart,

--- a/controllers/testutils/new.go
+++ b/controllers/testutils/new.go
@@ -19,10 +19,11 @@ import (
 
 // NewExtendedDaemonsetOptions used to provide creation options to the NewExtendedDaemonset function
 type NewExtendedDaemonsetOptions struct {
-	ExtraLabels      map[string]string
-	ExtraAnnotations map[string]string
-	CanaryStrategy   *datadoghqv1alpha1.ExtendedDaemonSetSpecStrategyCanary
-	RollingUpdate    *datadoghqv1alpha1.ExtendedDaemonSetSpecStrategyRollingUpdate
+	ExtraLabels        map[string]string
+	ExtraAnnotations   map[string]string
+	CanaryStrategy     *datadoghqv1alpha1.ExtendedDaemonSetSpecStrategyCanary
+	RollingUpdate      *datadoghqv1alpha1.ExtendedDaemonSetSpecStrategyRollingUpdate
+	ReconcileFrequency *metav1.Duration
 }
 
 // NewExtendedDaemonset returns new ExtendedDaemonSet instance
@@ -83,6 +84,10 @@ func NewExtendedDaemonset(ns, name, image string, options *NewExtendedDaemonsetO
 			for key, val := range options.ExtraAnnotations {
 				newDaemonset.ObjectMeta.Annotations[key] = val
 			}
+		}
+
+		if options.ReconcileFrequency != nil {
+			newDaemonset.Spec.Strategy.ReconcileFrequency = options.ReconcileFrequency
 		}
 	}
 	return newDaemonset

--- a/pkg/controller/utils/pod/pod.go
+++ b/pkg/controller/utils/pod/pod.go
@@ -46,8 +46,8 @@ func IsPodScheduled(pod *v1.Pod) (string, bool) {
 // 1. minReadySeconds == 0, or
 // 2. LastTransitionTime (is set) + minReadySeconds < current time
 func IsPodAvailable(pod *v1.Pod, minReadySeconds int32, now metav1.Time) bool {
-	if IsPodReady(pod) {
-		return true
+	if !IsPodReady(pod) {
+		return false
 	}
 
 	c := GetPodReadyCondition(pod.Status)

--- a/pkg/controller/utils/pod/pod_test.go
+++ b/pkg/controller/utils/pod/pod_test.go
@@ -201,3 +201,80 @@ func Test_MostRecentRestart(t *testing.T) {
 		})
 	}
 }
+
+func TestIsPodAvailable(t *testing.T) {
+	now := metav1.Now()
+
+	type args struct {
+		pod             *v1.Pod
+		minReadySeconds int32
+		now             metav1.Time
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "Not available, because not ready",
+			args: args{
+				pod:             newPod(now, false, 0),
+				minReadySeconds: 0,
+				now:             now,
+			},
+			want: false,
+		},
+		{
+			name: "Not available, Pod ready, but not since enough time",
+			args: args{
+				pod:             newPod(now, true, 0),
+				minReadySeconds: 1,
+				now:             now,
+			},
+			want: false,
+		},
+		{
+			name: "Available, Pod ready and minReady == 0",
+			args: args{
+				pod:             newPod(now, true, 0),
+				minReadySeconds: 0,
+				now:             now,
+			},
+			want: true,
+		},
+		{
+			name: "Available, Pod ready since enough time",
+			args: args{
+				pod:             newPod(now, true, 51),
+				minReadySeconds: 50,
+				now:             now,
+			},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsPodAvailable(tt.args.pod, tt.args.minReadySeconds, tt.args.now); got != tt.want {
+				t.Errorf("IsPodAvailable() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func newPod(now metav1.Time, ready bool, beforeSec int) *v1.Pod {
+	conditionStatus := v1.ConditionFalse
+	if ready {
+		conditionStatus = v1.ConditionTrue
+	}
+	return &v1.Pod{
+		Status: v1.PodStatus{
+			Conditions: []v1.PodCondition{
+				{
+					Type:               v1.PodReady,
+					LastTransitionTime: metav1.NewTime(now.Time.Add(-1 * time.Duration(beforeSec) * time.Second)),
+					Status:             conditionStatus,
+				},
+			},
+		},
+	}
+}


### PR DESCRIPTION
### What does this PR do?

Fix the function `IsPodAvailable()` used by the controller to compute the number of available Pods.

### Motivation

This behaviour was the origin of a nasty bug with which the controller  didn't respect the "MaxUnavailable" parameter.

The controller was considering too many Pods as available, for example, Pods in ImagePullBackoff were considered as available.

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Create a EDS instance on a multi nodes cluster (you can use the kand and the `examples/kind-cluster-configuration.yaml`)

```yaml
apiVersion: datadoghq.com/v1alpha1
kind: ExtendedDaemonSet
metadata:
  name: foo
spec:
  strategy:
    rollingUpdate:
      maxParallelPodCreation: 1
      slowStartIntervalDuration: 1m
      maxUnavailable: 1
  template:
    spec: 
      containers:
      - name: daemon
        image: k8s.gcr.io/pause:3.0
      tolerations:
      - operator: Exists
```

when the EDS properly deployed, update it with: 

```yaml
apiVersion: datadoghq.com/v1alpha1
kind: ExtendedDaemonSet
metadata:
  name: foo
spec:
  strategy:
    rollingUpdate:
      maxParallelPodCreation: 1
      slowStartIntervalDuration: 1m
      maxUnavailable: 1
  template:
    spec: 
      containers:
      - name: daemon
        image: k8s.gcr.io/pause:42
      tolerations:
      - operator: Exists
```

The image doesn't exist. so the new pod should in `ImagePullBackoff`.

wanted behaviour: Only one pod should be updated and in `ImagePullBackoff`