### PR TITLE
[Plugin] Fix commands in help output

### DIFF
--- a/pkg/plugin/get/get.go
+++ b/pkg/plugin/get/get.go
@@ -62,7 +62,7 @@ func NewCmdGet(streams genericclioptions.IOStreams) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:          "get [ExtendedDaemonSet name]",
 		Short:        "get ExtendedDaemonSet deployment(s)",
-		Example:      fmt.Sprintf(getExample, "kubectl"),
+		Example:      fmt.Sprintf(getExample, "kubectl eds"),
 		SilenceUsage: true,
 		RunE: func(c *cobra.Command, args []string) error {
 			if err := o.complete(c, args); err != nil {

--- a/pkg/plugin/get/geters.go
+++ b/pkg/plugin/get/geters.go
@@ -62,7 +62,7 @@ func NewCmdGetERS(streams genericclioptions.IOStreams) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:          "get-ers [ExtendedDaemonSetReplicaset name]",
 		Short:        "get-ers ExtendedDaemonSetReplicaset deployment(s)",
-		Example:      fmt.Sprintf(getErsExample, "kubectl"),
+		Example:      fmt.Sprintf(getErsExample, "kubectl eds"),
 		SilenceUsage: true,
 		RunE: func(c *cobra.Command, args []string) error {
 			if err := o.complete(c, args); err != nil {

--- a/pkg/plugin/pods/pods.go
+++ b/pkg/plugin/pods/pods.go
@@ -56,7 +56,7 @@ func NewCmdPods(streams genericclioptions.IOStreams) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:          "pods [flags] [ExtendedDaemonSet name]",
 		Short:        "print the list pods managed by the EDS",
-		Example:      fmt.Sprintf(podsExample, "kubectl"),
+		Example:      fmt.Sprintf(podsExample, "kubectl eds"),
 		SilenceUsage: true,
 		RunE: func(c *cobra.Command, args []string) error {
 			if err := o.complete(c, args); err != nil {


### PR DESCRIPTION
### What does this PR do?

Add missing `eds` to the help commands

### Describe your test plan

Run the commands with --help
