### PR TITLE
persist manual unpause until end of a canary deployment, and then reset

### DIFF
--- a/api/v1alpha1/const.go
+++ b/api/v1alpha1/const.go
@@ -22,6 +22,8 @@ const (
 	ExtendedDaemonSetCanaryPausedAnnotationKey = "extendeddaemonset.datadoghq.com/canary-paused"
 	// ExtendedDaemonSetCanaryPausedReasonAnnotationKey annotation key used on ExtendedDaemonset to provide a reason that the a canary deployment is paused.
 	ExtendedDaemonSetCanaryPausedReasonAnnotationKey = "extendeddaemonset.datadoghq.com/canary-paused-reason"
+	// ExtendedDaemonSetCanaryUnpausedAnnotationKey annotation key used on ExtendedDaemonset in order to detect if a canary deployment is manually unpaused.
+	ExtendedDaemonSetCanaryUnpausedAnnotationKey = "extendeddaemonset.datadoghq.com/canary-unpaused"
 	// ExtendedDaemonSetCanaryFailedAnnotationKey annotation key used on ExtendedDaemonset in order to detect if a canary deployment has failed.
 	ExtendedDaemonSetCanaryFailedAnnotationKey = "extendeddaemonset.datadoghq.com/canary-failed"
 	// ExtendedDaemonSetCanaryFailedReasonAnnotationKey annotation key used on ExtendedDaemonset in order to provide a reason that the a canary deployment is failed.

--- a/api/v1alpha1/const.go
+++ b/api/v1alpha1/const.go
@@ -36,4 +36,9 @@ const (
 	ExtendedDaemonSetRessourceNodeAnnotationKey = "resources.extendeddaemonset.datadoghq.com/%s.%s.%s"
 	// MD5NodeExtendedDaemonSetAnnotationKey annotation key use on Pods in order to identify which Node Resources Overwride have been used to generate it.
 	MD5NodeExtendedDaemonSetAnnotationKey = "extendeddaemonset.datadoghq.com/nodehash"
+
+	// ValueStringTrue is the string value of bool `true`
+	ValueStringTrue = "true"
+	// ValueStringFalse is the string value of bool `false`
+	ValueStringFalse = "false"
 )

--- a/controllers/extendeddaemonset/controller.go
+++ b/controllers/extendeddaemonset/controller.go
@@ -569,6 +569,7 @@ func (r *Reconciler) cleanupReplicaSet(logger logr.Logger, rsList *datadoghqv1al
 func clearCanaryAnnotations(eds *datadoghqv1alpha1.ExtendedDaemonSet) {
 	delete(eds.Annotations, datadoghqv1alpha1.ExtendedDaemonSetCanaryPausedAnnotationKey)
 	delete(eds.Annotations, datadoghqv1alpha1.ExtendedDaemonSetCanaryPausedReasonAnnotationKey)
+	delete(eds.Annotations, datadoghqv1alpha1.ExtendedDaemonSetCanaryUnpausedAnnotationKey)
 	delete(eds.Annotations, datadoghqv1alpha1.ExtendedDaemonSetCanaryFailedAnnotationKey)
 	delete(eds.Annotations, datadoghqv1alpha1.ExtendedDaemonSetCanaryFailedReasonAnnotationKey)
 }

--- a/controllers/extendeddaemonset/controller.go
+++ b/controllers/extendeddaemonset/controller.go
@@ -218,6 +218,7 @@ func (r *Reconciler) updateInstanceWithCurrentRS(logger logr.Logger, now time.Ti
 	metaNow := metav1.NewTime(now)
 
 	var updateDaemonsetSpec bool
+	var updateDaemonsetAnnotations bool
 	// If the deployment is in Canary phase, then update status (and spec as needed)
 	if daemonset.Spec.Strategy.Canary != nil {
 
@@ -252,7 +253,7 @@ func (r *Reconciler) updateInstanceWithCurrentRS(logger logr.Logger, now time.Ti
 			}
 		} else {
 			// if the Canary Deployment is not active anymore remove the canary annotations
-			clearCanaryAnnotations(newDaemonset)
+			updateDaemonsetAnnotations = clearCanaryAnnotations(newDaemonset)
 		}
 	}
 
@@ -268,10 +269,11 @@ func (r *Reconciler) updateInstanceWithCurrentRS(logger logr.Logger, now time.Ti
 			return extendedDaemonsetCopy, reconcile.Result{}, fmt.Errorf("failed to update ExtendedDaemonSet status, %w", err)
 		}
 
-		if updateDaemonsetSpec {
+		if updateDaemonsetSpec || updateDaemonsetAnnotations {
 			// we use the `extendedDaemonsetCopy` instance to have last version. that contains the latest metadata info (resource version)
 			// Copy the spec part into the extendedDaemonsetCopy.
 			extendedDaemonsetCopy.Spec = *newDaemonset.Spec.DeepCopy()
+			extendedDaemonsetCopy.Annotations = newDaemonset.Annotations
 			// In case of canaryFailed, we also update the ExtendedDaemonset.Spec
 			logger.Info("Updating ExtendedDaemonSet.Spec")
 			if err := r.client.Update(context.TODO(), extendedDaemonsetCopy); err != nil {
@@ -566,12 +568,22 @@ func (r *Reconciler) cleanupReplicaSet(logger logr.Logger, rsList *datadoghqv1al
 	return utilserrors.NewAggregate(errs)
 }
 
-func clearCanaryAnnotations(eds *datadoghqv1alpha1.ExtendedDaemonSet) {
-	delete(eds.Annotations, datadoghqv1alpha1.ExtendedDaemonSetCanaryPausedAnnotationKey)
-	delete(eds.Annotations, datadoghqv1alpha1.ExtendedDaemonSetCanaryPausedReasonAnnotationKey)
-	delete(eds.Annotations, datadoghqv1alpha1.ExtendedDaemonSetCanaryUnpausedAnnotationKey)
-	delete(eds.Annotations, datadoghqv1alpha1.ExtendedDaemonSetCanaryFailedAnnotationKey)
-	delete(eds.Annotations, datadoghqv1alpha1.ExtendedDaemonSetCanaryFailedReasonAnnotationKey)
+func clearCanaryAnnotations(eds *datadoghqv1alpha1.ExtendedDaemonSet) bool {
+	keysToDelete := []string{
+		datadoghqv1alpha1.ExtendedDaemonSetCanaryPausedAnnotationKey,
+		datadoghqv1alpha1.ExtendedDaemonSetCanaryPausedReasonAnnotationKey,
+		datadoghqv1alpha1.ExtendedDaemonSetCanaryUnpausedAnnotationKey,
+		datadoghqv1alpha1.ExtendedDaemonSetCanaryFailedAnnotationKey,
+		datadoghqv1alpha1.ExtendedDaemonSetCanaryFailedReasonAnnotationKey,
+	}
+	var updated bool
+	for _, key := range keysToDelete {
+		if _, ok := eds.Annotations[key]; ok {
+			delete(eds.Annotations, key)
+			updated = true
+		}
+	}
+	return updated
 }
 
 type podsCounterType struct {

--- a/controllers/extendeddaemonset/controller_test.go
+++ b/controllers/extendeddaemonset/controller_test.go
@@ -915,8 +915,8 @@ func TestReconcileExtendedDaemonSet_updateInstanceWithCurrentRS(t *testing.T) {
 				t.Errorf("ReconcileExtendedDaemonSet.updateInstanceWithCurrentRS() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			assert.Equal(t, tt.want, got, "econcileExtendedDaemonSet.updateInstanceWithCurrentRS()")
-			assert.Equal(t, tt.wantResult, got1, "econcileExtendedDaemonSet.updateInstanceWithCurrentRS().result")
+			assert.Equal(t, tt.want, got, "ReconcileExtendedDaemonSet.updateInstanceWithCurrentRS()")
+			assert.Equal(t, tt.wantResult, got1, "ReconcileExtendedDaemonSet.updateInstanceWithCurrentRS().result")
 		})
 	}
 }

--- a/controllers/extendeddaemonset/utils.go
+++ b/controllers/extendeddaemonset/utils.go
@@ -60,7 +60,6 @@ func IsCanaryDeploymentEnded(specCanary *datadoghqv1alpha1.ExtendedDaemonSetSpec
 
 // IsCanaryDeploymentPaused checks if the Canary deployment has been paused
 func IsCanaryDeploymentPaused(dsAnnotations map[string]string, ers *datadoghqv1alpha1.ExtendedDaemonSetReplicaSet) (bool, datadoghqv1alpha1.ExtendedDaemonSetStatusReason) {
-
 	// check ERS status to detect if a Canary paused
 	if ers != nil && conditions.IsConditionTrue(&ers.Status, datadoghqv1alpha1.ConditionTypeCanaryPaused) {
 		cond := conditions.GetExtendedDaemonSetReplicaSetStatusCondition(&ers.Status, datadoghqv1alpha1.ConditionTypeCanaryPaused)
@@ -70,7 +69,7 @@ func IsCanaryDeploymentPaused(dsAnnotations map[string]string, ers *datadoghqv1a
 
 	// Check annotations is a user have added the pause annotation.
 	isPaused, found := dsAnnotations[datadoghqv1alpha1.ExtendedDaemonSetCanaryPausedAnnotationKey]
-	if found && isPaused == "true" { //nolint:goconst
+	if found && isPaused == v1alpha1.ValueStringTrue {
 		if reason, found := dsAnnotations[datadoghqv1alpha1.ExtendedDaemonSetCanaryPausedReasonAnnotationKey]; found {
 			return true, datadoghqv1alpha1.ExtendedDaemonSetStatusReason(reason)
 		}
@@ -83,7 +82,7 @@ func IsCanaryDeploymentPaused(dsAnnotations map[string]string, ers *datadoghqv1a
 func IsCanaryDeploymentUnpaused(dsAnnotations map[string]string) bool {
 	isUnpaused, found := dsAnnotations[datadoghqv1alpha1.ExtendedDaemonSetCanaryUnpausedAnnotationKey]
 	if found {
-		return isUnpaused == "true" //nolint:goconst
+		return isUnpaused == v1alpha1.ValueStringTrue
 	}
 	return false
 }
@@ -107,7 +106,7 @@ func IsCanaryDeploymentFailed(dsAnnotations map[string]string, ers *datadoghqv1a
 
 	// Check also failed annotations if a user wanted to force a canary failure
 	if value, found := dsAnnotations[datadoghqv1alpha1.ExtendedDaemonSetCanaryFailedAnnotationKey]; found {
-		return value == "true"
+		return value == v1alpha1.ValueStringTrue
 	}
 	return false
 }

--- a/controllers/extendeddaemonset/utils.go
+++ b/controllers/extendeddaemonset/utils.go
@@ -79,6 +79,15 @@ func IsCanaryDeploymentPaused(dsAnnotations map[string]string, ers *datadoghqv1a
 	return false, ""
 }
 
+// IsCanaryDeploymentUnpaused checks if the Canary deployment has been manually unpaused
+func IsCanaryDeploymentUnpaused(dsAnnotations map[string]string) bool {
+	isUnpaused, found := dsAnnotations[datadoghqv1alpha1.ExtendedDaemonSetCanaryUnpausedAnnotationKey]
+	if found {
+		return isUnpaused == "true" //nolint:goconst
+	}
+	return false
+}
+
 // IsCanaryDeploymentValid used to know if the Canary deployment has been declared
 // valid even if its duration has not finished yet.
 // If the ExtendedDaemonSet has the corresponding annotation: return true

--- a/controllers/extendeddaemonsetreplicaset/strategy/canary.go
+++ b/controllers/extendeddaemonsetreplicaset/strategy/canary.go
@@ -51,6 +51,7 @@ func manageCanaryStatus(annotations map[string]string, params *Parameters, now t
 
 	result.IsFailed = eds.IsCanaryDeploymentFailed(annotations, params.Replicaset)
 	result.IsPaused, _ = eds.IsCanaryDeploymentPaused(annotations, params.Replicaset)
+	result.IsUnpaused = eds.IsCanaryDeploymentUnpaused(annotations)
 
 	var (
 		metaNow = metav1.NewTime(now)
@@ -194,7 +195,7 @@ func manageCanaryPodFailures(pods []*v1.Pod, params *Parameters, result *Result,
 				"MaxRestarts", autoFailMaxRestarts,
 				"Reason", highRestartReason,
 			)
-		} else if !result.IsPaused && autoPauseEnabled {
+		} else if !result.IsPaused && autoPauseEnabled && !result.IsUnpaused {
 			// Handle cases related to failure to start states
 			if cannotStart {
 				result.IsPaused = true

--- a/controllers/extendeddaemonsetreplicaset/strategy/canary.go
+++ b/controllers/extendeddaemonsetreplicaset/strategy/canary.go
@@ -186,7 +186,8 @@ func manageCanaryPodFailures(pods []*v1.Pod, params *Parameters, result *Result,
 			continue
 		}
 
-		if autoFailEnabled && restartCount > autoFailMaxRestarts {
+		switch {
+		case autoFailEnabled && restartCount > autoFailMaxRestarts:
 			result.IsFailed = true
 			result.FailedReason = highRestartReason
 			params.Logger.Info(
@@ -195,7 +196,11 @@ func manageCanaryPodFailures(pods []*v1.Pod, params *Parameters, result *Result,
 				"MaxRestarts", autoFailMaxRestarts,
 				"Reason", highRestartReason,
 			)
-		} else if !result.IsPaused && autoPauseEnabled && !result.IsUnpaused {
+		case result.IsUnpaused:
+			// Unpausing is a manual action and takes precedence
+			result.IsPaused = false
+			result.PausedReason = ""
+		case !result.IsPaused && autoPauseEnabled:
 			// Handle cases related to failure to start states
 			if cannotStart {
 				result.IsPaused = true

--- a/controllers/extendeddaemonsetreplicaset/strategy/type.go
+++ b/controllers/extendeddaemonsetreplicaset/strategy/type.go
@@ -63,6 +63,8 @@ type Result struct {
 	IsPaused bool
 	// PausedReason provides the reason for the paused deployment
 	PausedReason datadoghqv1alpha1.ExtendedDaemonSetStatusReason
+	// IsUnpaused represents if the deployment was manually unpaused
+	IsUnpaused bool
 
 	// IsFailed represents failed state of the deployment
 	IsFailed bool

--- a/examples/foo-eds_v1.yaml
+++ b/examples/foo-eds_v1.yaml
@@ -7,6 +7,8 @@ spec:
     canary:
       replicas: 1
       duration: 5m
+      autoFail:
+        enabled: false
     rollingUpdate:
       maxParallelPodCreation: 1
       slowStartIntervalDuration: 1m

--- a/pkg/plugin/canary/fail.go
+++ b/pkg/plugin/canary/fail.go
@@ -133,16 +133,19 @@ func (o *failOptions) run() error {
 	}
 
 	if eds.Spec.Strategy.Canary == nil {
-		return fmt.Errorf("the ExtendedDaemonset does not have a canary")
+		return fmt.Errorf("the ExtendedDaemonset does not have a canary strategy")
+	}
+	if eds.Status.Canary == nil {
+		return fmt.Errorf("the ExtendedDaemonset does not have an active canary deployment")
 	}
 
 	newEds := eds.DeepCopy()
 	if newEds.Annotations == nil {
 		newEds.Annotations = make(map[string]string)
 	} else if isFailed, ok := newEds.Annotations[v1alpha1.ExtendedDaemonSetCanaryFailedAnnotationKey]; ok {
-		if o.failStatus && isFailed == "true" {
+		if o.failStatus && isFailed == "true" { //nolint:goconst
 			return fmt.Errorf("canary deployment already failed")
-		} else if !o.failStatus && isFailed == "false" {
+		} else if !o.failStatus && isFailed == "false" { //nolint:goconst
 			return fmt.Errorf("canary deployment already reset")
 		}
 	}

--- a/pkg/plugin/canary/fail.go
+++ b/pkg/plugin/canary/fail.go
@@ -143,9 +143,9 @@ func (o *failOptions) run() error {
 	if newEds.Annotations == nil {
 		newEds.Annotations = make(map[string]string)
 	} else if isFailed, ok := newEds.Annotations[v1alpha1.ExtendedDaemonSetCanaryFailedAnnotationKey]; ok {
-		if o.failStatus && isFailed == "true" { //nolint:goconst
+		if o.failStatus && isFailed == v1alpha1.ValueStringTrue {
 			return fmt.Errorf("canary deployment already failed")
-		} else if !o.failStatus && isFailed == "false" { //nolint:goconst
+		} else if !o.failStatus && isFailed == v1alpha1.ValueStringFalse {
 			return fmt.Errorf("canary deployment already reset")
 		}
 	}

--- a/pkg/plugin/canary/pause.go
+++ b/pkg/plugin/canary/pause.go
@@ -22,10 +22,8 @@ import (
 )
 
 const (
-	cmdPause    = true
-	cmdUnpause  = false
-	stringTrue  = "true"
-	stringFalse = "false"
+	cmdPause   = true
+	cmdUnpause = false
 )
 
 var (
@@ -174,20 +172,20 @@ func (o *pauseOptions) run() error {
 	if newEds.Annotations == nil {
 		newEds.Annotations = make(map[string]string)
 	} else if isPaused, ok := newEds.Annotations[v1alpha1.ExtendedDaemonSetCanaryPausedAnnotationKey]; ok {
-		if o.pauseStatus && isPaused == stringTrue {
+		if o.pauseStatus && isPaused == v1alpha1.ValueStringTrue {
 			return fmt.Errorf("canary deployment already paused")
-		} else if !o.pauseStatus && isPaused == stringFalse {
+		} else if !o.pauseStatus && isPaused == v1alpha1.ValueStringFalse {
 			return fmt.Errorf("canary deployment is not paused; cannot unpause")
 		}
 	}
 	// Set appropriate annotation depending on whether cmd is to pause or unpause
 	if o.pauseStatus {
-		newEds.Annotations[v1alpha1.ExtendedDaemonSetCanaryPausedAnnotationKey] = stringTrue
+		newEds.Annotations[v1alpha1.ExtendedDaemonSetCanaryPausedAnnotationKey] = v1alpha1.ValueStringTrue
 		// Set to false in case it was previously true
-		newEds.Annotations[v1alpha1.ExtendedDaemonSetCanaryUnpausedAnnotationKey] = stringFalse
+		newEds.Annotations[v1alpha1.ExtendedDaemonSetCanaryUnpausedAnnotationKey] = v1alpha1.ValueStringFalse
 	} else {
-		newEds.Annotations[v1alpha1.ExtendedDaemonSetCanaryPausedAnnotationKey] = stringFalse
-		newEds.Annotations[v1alpha1.ExtendedDaemonSetCanaryUnpausedAnnotationKey] = stringTrue
+		newEds.Annotations[v1alpha1.ExtendedDaemonSetCanaryPausedAnnotationKey] = v1alpha1.ValueStringFalse
+		newEds.Annotations[v1alpha1.ExtendedDaemonSetCanaryUnpausedAnnotationKey] = v1alpha1.ValueStringTrue
 	}
 
 	patch := client.MergeFrom(eds)


### PR DESCRIPTION
### What does this PR do?

Previously, the ability to manually `unpause` a Canary deployment was added. However, if `AutoPause` is enabled and the Canary deployment exceeds the number of `maxRestarts` (for instance), then the Canary will be automatically paused again following an `unpause` action.

This PR persists a manual `unpause` action by storing it in an annotation, and inhibits the `AutoPause` feature until the Canary deployment ends and the annotation is removed.

### Motivation

Better user experience

### Additional Notes

Note that a user cannot `unpause` to effectively disable `AutoPause`, and then change their mind and re-enable `AutoPause` during the ongoing Canary deployment using the plugin. (They can manually edit the unpause annotation as a workaround.) Manual `pause`/`unpause` actions can be executed with the plugin at will.

### Describe your test plan

- `make build` (this also builds the plugin)
- Start a `kind` cluster
- Edit `config/manager/manager.yaml` and `config/manager/kustomization.yaml` to use image `test/extendeddaemonset:test` and image pull policy `Never`
- `make install`
- `make IMG=test/extendeddaemonset:test docker-build` 
- `kind load docker-image test/extendeddaemonset:test`
- `make deploy`
- Then apply the `ExtendedDaemonSet`s in `examples/` to start a canary deployment
- `bin/kubectl-eds canary pause foo`; verify it is paused (with `kubectl-eds get` and by checking the annotation)
- `bin/kubectl-eds canary unpause foo`; verify it is unpaused
- When canary deployment finishes, verify the `canary-unpaused` annotation is cleared
- Try a test with a canary deployment that is in CLB (can use `bash:latest` image) and `AutoPause` is enabled. Make sure that, after the canary is automatically paused, `bin/kubectl-eds canary unpause foo` allows the canary deployment to finish despite the restarts.
- Other behaviors to try: `canary fail foo`, `canary pause foo -> canary unpause foo`