### PR TITLE
Support pausing and freezing non-canary replicasets

### DIFF
--- a/api/v1alpha1/const.go
+++ b/api/v1alpha1/const.go
@@ -36,6 +36,10 @@ const (
 	ExtendedDaemonSetRessourceNodeAnnotationKey = "resources.extendeddaemonset.datadoghq.com/%s.%s.%s"
 	// MD5NodeExtendedDaemonSetAnnotationKey annotation key use on Pods in order to identify which Node Resources Overwride have been used to generate it.
 	MD5NodeExtendedDaemonSetAnnotationKey = "extendeddaemonset.datadoghq.com/nodehash"
+	// ExtendedDaemonSetRollingUpdatePausedAnnotationKey annotation key used on ExtendedDaemonset in order to detect if a rolling update is paused.
+	ExtendedDaemonSetRollingUpdatePausedAnnotationKey = "extendeddaemonset.datadoghq.com/rolling-update-paused"
+	// ExtendedDaemonSetRolloutFrozenAnnotationKey annotation key used on ExtendedDaemonset in order to detect if a rollout is frozen.
+	ExtendedDaemonSetRolloutFrozenAnnotationKey = "extendeddaemonset.datadoghq.com/rollout-frozen"
 
 	// ValueStringTrue is the string value of bool `true`.
 	ValueStringTrue = "true"

--- a/api/v1alpha1/extendeddaemonset_types.go
+++ b/api/v1alpha1/extendeddaemonset_types.go
@@ -110,6 +110,10 @@ type ExtendedDaemonSetStatusState string
 const (
 	// ExtendedDaemonSetStatusStateRunning the ExtendedDaemonSet is currently Running.
 	ExtendedDaemonSetStatusStateRunning ExtendedDaemonSetStatusState = "Running"
+	// ExtendedDaemonSetStatusStateRollingUpdatePaused the ExtendedDaemonSet rolling update is paused.
+	ExtendedDaemonSetStatusStateRollingUpdatePaused ExtendedDaemonSetStatusState = "RollingUpdate Paused"
+	// ExtendedDaemonSetStatusStateRolloutFrozen the ExtendedDaemonSet rollout is frozen.
+	ExtendedDaemonSetStatusStateRolloutFrozen ExtendedDaemonSetStatusState = "Rollout frozen"
 	// ExtendedDaemonSetStatusStateCanary the ExtendedDaemonSet currently run a new version with a Canary deployment.
 	ExtendedDaemonSetStatusStateCanary ExtendedDaemonSetStatusState = "Canary"
 	// ExtendedDaemonSetStatusStateCanaryPaused the Canary deployment of the ExtendedDaemonSet is paused.

--- a/api/v1alpha1/extendeddaemonsetreplicaset_types.go
+++ b/api/v1alpha1/extendeddaemonsetreplicaset_types.go
@@ -78,6 +78,10 @@ type ExtendedDaemonSetReplicaSetConditionType string
 const (
 	// ConditionTypeActive ExtendedDaemonSetReplicaSet is active.
 	ConditionTypeActive ExtendedDaemonSetReplicaSetConditionType = "Active"
+	// ConditionTypeRollingUpdatePaused ExtendedDaemonSetReplicaSet is active but the rolling update is paused.
+	ConditionTypeRollingUpdatePaused ExtendedDaemonSetReplicaSetConditionType = "RollingUpdatePaused"
+	// ConditionTypeRolloutFrozen ExtendedDaemonSetReplicaSet is active but the rollout is frozen.
+	ConditionTypeRolloutFrozen ExtendedDaemonSetReplicaSetConditionType = "RolloutFrozen"
 	// ConditionTypeCanary ExtendedDaemonSetReplicaSet is in canary mode.
 	ConditionTypeCanary ExtendedDaemonSetReplicaSetConditionType = "Canary"
 	// ConditionTypeReconcileError the controller wasn't able to run properly the reconcile loop with this ExtendedDaemonSetReplicaSet.

--- a/config/rbac/leader_election_role.yaml
+++ b/config/rbac/leader_election_role.yaml
@@ -31,3 +31,15 @@ rules:
   verbs:
   - create
   - patch
+- apiGroups:
+  - "coordination.k8s.io"
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete

--- a/controllers/extendeddaemonset/metrics.go
+++ b/controllers/extendeddaemonset/metrics.go
@@ -27,6 +27,8 @@ const (
 	extendeddaemonsetStatusCanaryNumberOfNodes      = "eds_status_canary_node_number"
 	extendeddaemonsetStatusCanaryPaused             = "eds_status_canary_paused"
 	extendeddaemonsetStatusCanaryFailed             = "eds_status_canary_failed"
+	extendeddaemonsetStatusRollingUpdatePaused      = "eds_status_rolling_update_paused"
+	extendeddaemonsetStatusRolloutFrozen            = "eds_status_rollout_frozen"
 	extendeddaemonsetLabels                         = "eds_labels"
 )
 
@@ -289,6 +291,54 @@ func generateMetricFamilies() []ksmetric.FamilyGenerator {
 				val := float64(0)
 				if eds.Status.Canary != nil {
 					val = float64(len(eds.Status.Canary.Nodes))
+				}
+
+				return &ksmetric.Family{
+					Metrics: []*ksmetric.Metric{
+						{
+							Value:       val,
+							LabelKeys:   labelKeys,
+							LabelValues: labelValues,
+						},
+					},
+				}
+			},
+		},
+		{
+			Name: extendeddaemonsetStatusRollingUpdatePaused,
+			Type: ksmetric.Gauge,
+			Help: "The paused state of a rolling update, 1 if paused, 0 otherwise",
+			GenerateFunc: func(obj interface{}) *ksmetric.Family {
+				eds := obj.(*datadoghqv1alpha1.ExtendedDaemonSet)
+				labelKeys, labelValues := utils.GetLabelsValues(&eds.ObjectMeta)
+				val := float64(0)
+
+				if eds.Status.State == datadoghqv1alpha1.ExtendedDaemonSetStatusStateRollingUpdatePaused {
+					val = 1
+				}
+
+				return &ksmetric.Family{
+					Metrics: []*ksmetric.Metric{
+						{
+							Value:       val,
+							LabelKeys:   labelKeys,
+							LabelValues: labelValues,
+						},
+					},
+				}
+			},
+		},
+		{
+			Name: extendeddaemonsetStatusRolloutFrozen,
+			Type: ksmetric.Gauge,
+			Help: "The frozen state of a rollout, 1 if frozen, 0 otherwise",
+			GenerateFunc: func(obj interface{}) *ksmetric.Family {
+				eds := obj.(*datadoghqv1alpha1.ExtendedDaemonSet)
+				labelKeys, labelValues := utils.GetLabelsValues(&eds.ObjectMeta)
+				val := float64(0)
+
+				if eds.Status.State == datadoghqv1alpha1.ExtendedDaemonSetStatusStateRolloutFrozen {
+					val = 1
 				}
 
 				return &ksmetric.Family{

--- a/controllers/extendeddaemonset/utils.go
+++ b/controllers/extendeddaemonset/utils.go
@@ -17,6 +17,16 @@ import (
 	"github.com/DataDog/extendeddaemonset/controllers/extendeddaemonsetreplicaset/conditions"
 )
 
+// IsRollingUpdatePaused checks if a rolling update has been paused.
+func IsRollingUpdatePaused(dsAnnotations map[string]string) bool {
+	return dsAnnotations[datadoghqv1alpha1.ExtendedDaemonSetRollingUpdatePausedAnnotationKey] == datadoghqv1alpha1.ValueStringTrue
+}
+
+// IsRolloutFrozen checks if a rollout has been freezed.
+func IsRolloutFrozen(dsAnnotations map[string]string) bool {
+	return dsAnnotations[datadoghqv1alpha1.ExtendedDaemonSetRolloutFrozenAnnotationKey] == datadoghqv1alpha1.ValueStringTrue
+}
+
 // IsCanaryDeploymentEnded used to know if the Canary duration has finished.
 // If the duration is completed: return true
 // If the duration is not completed: return false and the remaining duration.

--- a/controllers/extendeddaemonset_e2e_test.go
+++ b/controllers/extendeddaemonset_e2e_test.go
@@ -706,17 +706,6 @@ func withUpdate(obj client.Object, desc string) condFn {
 	}
 }
 
-func withList(listOptions []client.ListOption, obj client.ObjectList, desc string, condition condFn) condFn {
-	return func() bool {
-		err := k8sClient.List(context.Background(), obj, listOptions...)
-		if err != nil {
-			fmt.Fprintf(GinkgoWriter, "Failed to list %s: %v", desc, err)
-			return false
-		}
-		return condition()
-	}
-}
-
 func clearCanaryAnnotations(eds *datadoghqv1alpha1.ExtendedDaemonSet) bool {
 	keysToDelete := []string{
 		datadoghqv1alpha1.ExtendedDaemonSetCanaryPausedAnnotationKey,

--- a/controllers/extendeddaemonset_test.go
+++ b/controllers/extendeddaemonset_test.go
@@ -14,11 +14,15 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	datadoghqv1alpha1 "github.com/DataDog/extendeddaemonset/api/v1alpha1"
+	"github.com/DataDog/extendeddaemonset/controllers/extendeddaemonsetreplicaset/conditions"
+	"github.com/DataDog/extendeddaemonset/controllers/extendeddaemonsetreplicaset/strategy"
 	"github.com/DataDog/extendeddaemonset/controllers/testutils"
 	// +kubebuilder:scaffold:imports
 )
@@ -82,6 +86,378 @@ var _ = Describe("ExtendedDaemonSet Controller", func() {
 				)
 			},
 			)
+		})
+	})
+})
+
+var _ = Describe("ExtendedDaemonSet Rolling Update Pause", func() {
+	const timeout = time.Second * 30
+	const interval = time.Second * 2
+
+	intString10 := intstr.FromInt(10)
+	reconcileFrequency := &metav1.Duration{Duration: time.Millisecond * 100}
+	namespace := testConfig.namespace
+	ctx := context.Background()
+
+	Context("Initial deployment", func() {
+		var firstERSName, secondERSName string
+		name := "eds-pause"
+		key := types.NamespacedName{
+			Namespace: namespace,
+			Name:      name,
+		}
+
+		It("Should deploy", func() {
+			edsOptions := &testutils.NewExtendedDaemonsetOptions{
+				CanaryStrategy: nil,
+				RollingUpdate: &datadoghqv1alpha1.ExtendedDaemonSetSpecStrategyRollingUpdate{
+					MaxPodSchedulerFailure: &intString10,
+					MaxUnavailable:         &intString10,
+					MaxParallelPodCreation: datadoghqv1alpha1.NewInt32(20),
+					SlowStartIntervalDuration: &metav1.Duration{
+						Duration: 1 * time.Millisecond,
+					},
+					SlowStartAdditiveIncrease: &intString10,
+				},
+				ReconcileFrequency: reconcileFrequency,
+			}
+			eds := testutils.NewExtendedDaemonset(namespace, name, "k8s.gcr.io/pause:latest", edsOptions)
+			Expect(k8sClient.Create(ctx, eds)).Should(Succeed())
+
+			eds = &datadoghqv1alpha1.ExtendedDaemonSet{}
+			Eventually(withEDS(key, eds, func() bool {
+				return eds.Status.ActiveReplicaSet != ""
+			}), timeout, interval).Should(BeTrue(), func() string {
+				return fmt.Sprintf(
+					"ActiveReplicaSet should be set: %#v",
+					eds.Status,
+				)
+			},
+			)
+
+			firstERSName = eds.Status.ActiveReplicaSet
+
+			ers := &datadoghqv1alpha1.ExtendedDaemonSetReplicaSet{}
+			erskey := types.NamespacedName{
+				Namespace: namespace,
+				Name:      firstERSName,
+			}
+			Eventually(withERS(erskey, ers, func() bool {
+				return ers.Status.Desired == ers.Status.Current
+			}), timeout, interval).Should(BeTrue(), func() string {
+				return fmt.Sprintf(
+					"ers.Status.Desired should be equal to ers.Status.Current, status: %#v",
+					ers.Status,
+				)
+			},
+			)
+		})
+
+		It("Should not deploy with paused EDS", func() {
+			eds := &datadoghqv1alpha1.ExtendedDaemonSet{}
+			Expect(k8sClient.Get(ctx, key, eds)).Should(Succeed())
+			eds.Spec.Template.Spec.Containers[0].Image = "k8s.gcr.io/pause:3.0" // Trigger a new ERS
+			if eds.Annotations == nil {
+				eds.Annotations = make(map[string]string)
+			}
+			eds.Annotations["extendeddaemonset.datadoghq.com/rolling-update-paused"] = "true" // Pause the rolling update
+			Expect(k8sClient.Update(ctx, eds)).Should(Succeed())
+
+			eds = &datadoghqv1alpha1.ExtendedDaemonSet{}
+			Eventually(withEDS(key, eds, func() bool {
+				return eds.Status.ActiveReplicaSet != "" && eds.Status.ActiveReplicaSet != firstERSName
+			}), timeout, interval).Should(BeTrue(), func() string {
+				return fmt.Sprintf(
+					"ActiveReplicaSet should be updated: %#v, old ers: %s",
+					eds.Status,
+					firstERSName,
+				)
+			},
+			)
+
+			secondERSName = eds.Status.ActiveReplicaSet
+
+			Expect(func() bool {
+				return eds.Status.State == datadoghqv1alpha1.ExtendedDaemonSetStatusStateRollingUpdatePaused
+			}()).Should(BeTrue(), func() string {
+				return fmt.Sprintf(
+					"EDS status should be updated: %#v",
+					eds.Status,
+				)
+			})
+
+			ers := &datadoghqv1alpha1.ExtendedDaemonSetReplicaSet{}
+			erskey := types.NamespacedName{
+				Namespace: namespace,
+				Name:      secondERSName,
+			}
+			Eventually(withERS(erskey, ers, func() bool {
+				return ers.Status.Desired != ers.Status.Current
+			}), timeout, interval).Should(BeTrue(), func() string {
+				return fmt.Sprintf(
+					"ers.Status.Desired should not be equal to ers.Status.Current, status: %#v",
+					ers.Status,
+				)
+			},
+			)
+
+			Expect(func() bool {
+				expectedStatus := ers.Status.Status == string(strategy.ReplicaSetStatusActive)
+				expectedCondition := conditions.IsConditionTrue(&ers.Status, datadoghqv1alpha1.ConditionTypeRollingUpdatePaused)
+
+				return expectedStatus && expectedCondition
+			}()).Should(BeTrue(), func() string {
+				return fmt.Sprintf(
+					"ERS status should be updated: %#v",
+					ers.Status,
+				)
+			})
+		})
+
+		It("Should not let nodes without pods even when paused", func() {
+			podList := &corev1.PodList{}
+			listOptions := []client.ListOption{
+				client.InNamespace(namespace),
+				client.MatchingLabels{
+					"extendeddaemonset.datadoghq.com/name": name,
+				},
+			}
+			Eventually(withList(listOptions, podList, "pods", func() bool {
+				return len(podList.Items) == fakeNodesCount
+			}), timeout, interval).Should(BeTrue(), func() string {
+				return fmt.Sprintf(
+					"Should get all the pods, got: %d",
+					len(podList.Items),
+				)
+			},
+			)
+
+			extraNode := testutils.NewNode(fmt.Sprintf("node%d", fakeNodesCount+1), nil)
+			Expect(k8sClient.Create(context.Background(), extraNode)).Should(Succeed())
+
+			podList = &corev1.PodList{}
+			Eventually(withList(listOptions, podList, "pods", func() bool {
+				return len(podList.Items) == fakeNodesCount+1
+			}), timeout, interval).Should(BeTrue(), func() string {
+				return fmt.Sprintf(
+					"Should get an extra pod, got: %d",
+					len(podList.Items),
+				)
+			},
+			)
+
+			Expect(k8sClient.Delete(context.Background(), extraNode)).Should(Succeed())
+		})
+
+		It("Should continue the rolling update when unpaused", func() {
+			eds := &datadoghqv1alpha1.ExtendedDaemonSet{}
+			Expect(k8sClient.Get(ctx, key, eds)).Should(Succeed())
+			eds.Annotations["extendeddaemonset.datadoghq.com/rolling-update-paused"] = "false" // Unpause the rolling update
+			Expect(k8sClient.Update(ctx, eds)).Should(Succeed())
+
+			eds = &datadoghqv1alpha1.ExtendedDaemonSet{}
+			Eventually(withEDS(key, eds, func() bool {
+				return eds.Status.State == datadoghqv1alpha1.ExtendedDaemonSetStatusStateRunning
+			}), timeout, interval).Should(BeTrue(), func() string {
+				return fmt.Sprintf(
+					"eds.Status should be updated: %#v",
+					eds.Status,
+				)
+			},
+			)
+
+			ers := &datadoghqv1alpha1.ExtendedDaemonSetReplicaSet{}
+			erskey := types.NamespacedName{
+				Namespace: namespace,
+				Name:      secondERSName,
+			}
+
+			Eventually(withERS(erskey, ers, func() bool {
+				expectedStatus := ers.Status.Status == string(strategy.ReplicaSetStatusActive)
+				expectedCondition := conditions.IsConditionTrue(&ers.Status, datadoghqv1alpha1.ConditionTypeActive)
+				expectedDesired := ers.Status.Desired == fakeNodesCount
+
+				return expectedStatus && expectedCondition && expectedDesired
+			}), timeout, interval).Should(BeTrue(), func() string {
+				return fmt.Sprintf(
+					"ERS status should be updated: %#v",
+					ers.Status,
+				)
+			},
+			)
+		})
+	})
+})
+
+var _ = Describe("ExtendedDaemonSet Rollout Freeze", func() {
+	const timeout = time.Second * 30
+	const interval = time.Second * 2
+
+	intString10 := intstr.FromInt(10)
+	reconcileFrequency := &metav1.Duration{Duration: time.Millisecond * 100}
+	namespace := testConfig.namespace
+	ctx := context.Background()
+
+	Context("Initial deployment", func() {
+		name := "eds-freeze"
+		key := types.NamespacedName{
+			Namespace: namespace,
+			Name:      name,
+		}
+
+		It("Should not deploy with frozen EDS", func() {
+			edsOptions := &testutils.NewExtendedDaemonsetOptions{
+				CanaryStrategy: nil,
+				RollingUpdate: &datadoghqv1alpha1.ExtendedDaemonSetSpecStrategyRollingUpdate{
+					MaxPodSchedulerFailure: &intString10,
+					MaxUnavailable:         &intString10,
+					MaxParallelPodCreation: datadoghqv1alpha1.NewInt32(20),
+					SlowStartIntervalDuration: &metav1.Duration{
+						Duration: 1 * time.Millisecond,
+					},
+					SlowStartAdditiveIncrease: &intString10,
+				},
+				ReconcileFrequency: reconcileFrequency,
+				ExtraAnnotations:   map[string]string{"extendeddaemonset.datadoghq.com/rollout-frozen": "true"},
+			}
+			eds := testutils.NewExtendedDaemonset(namespace, name, "k8s.gcr.io/pause:latest", edsOptions)
+			Expect(k8sClient.Create(ctx, eds)).Should(Succeed())
+
+			eds = &datadoghqv1alpha1.ExtendedDaemonSet{}
+			Eventually(withEDS(key, eds, func() bool {
+				return eds.Status.ActiveReplicaSet != ""
+			}), timeout, interval).Should(BeTrue(), func() string {
+				return fmt.Sprintf(
+					"ActiveReplicaSet should be set: %#v",
+					eds.Status,
+				)
+			},
+			)
+
+			Expect(func() bool {
+				return eds.Status.State == datadoghqv1alpha1.ExtendedDaemonSetStatusStateRolloutFrozen
+			}()).Should(BeTrue(), func() string {
+				return fmt.Sprintf(
+					"EDS status should be updated: %#v",
+					eds.Status,
+				)
+			})
+
+			ers := &datadoghqv1alpha1.ExtendedDaemonSetReplicaSet{}
+			erskey := types.NamespacedName{
+				Namespace: namespace,
+				Name:      eds.Status.ActiveReplicaSet,
+			}
+			Eventually(withERS(erskey, ers, func() bool {
+				expectedStatus := ers.Status.Status == string(strategy.ReplicaSetStatusActive)
+				expectedCondition := conditions.IsConditionTrue(&ers.Status, datadoghqv1alpha1.ConditionTypeRolloutFrozen)
+				expectedCurrent := (ers.Status.Current == 0) && (ers.Status.Desired != ers.Status.Current)
+
+				return expectedStatus && expectedCondition && expectedCurrent
+			}), timeout, interval).Should(BeTrue(), func() string {
+				return fmt.Sprintf(
+					"ERS status should be updated: %#v",
+					ers.Status,
+				)
+			},
+			)
+		})
+
+		It("Should continue the rollout when unfrozen", func() {
+			eds := &datadoghqv1alpha1.ExtendedDaemonSet{}
+			Expect(k8sClient.Get(ctx, key, eds)).Should(Succeed())
+			eds.Annotations["extendeddaemonset.datadoghq.com/rollout-frozen"] = "false" // Unfreeze the rollout
+			Expect(k8sClient.Update(ctx, eds)).Should(Succeed())
+
+			eds = &datadoghqv1alpha1.ExtendedDaemonSet{}
+			Eventually(withEDS(key, eds, func() bool {
+				return eds.Status.State == datadoghqv1alpha1.ExtendedDaemonSetStatusStateRunning
+			}), timeout, interval).Should(BeTrue(), func() string {
+				return fmt.Sprintf(
+					"EDS should be updated: %#v",
+					eds.Status,
+				)
+			},
+			)
+
+			ers := &datadoghqv1alpha1.ExtendedDaemonSetReplicaSet{}
+			erskey := types.NamespacedName{
+				Namespace: namespace,
+				Name:      eds.Status.ActiveReplicaSet,
+			}
+
+			Eventually(withERS(erskey, ers, func() bool {
+				expectedStatus := ers.Status.Status == string(strategy.ReplicaSetStatusActive)
+				expectedCondition := conditions.IsConditionTrue(&ers.Status, datadoghqv1alpha1.ConditionTypeActive)
+				expectedDesired := ers.Status.Desired == ers.Status.Current
+
+				return expectedStatus && expectedCondition && expectedDesired
+			}), timeout, interval).Should(BeTrue(), func() string {
+				return fmt.Sprintf(
+					"ERS status should be updated: %#v",
+					eds.Status,
+				)
+			},
+			)
+		})
+
+		It("Should not deploy to new nodes when frozen", func() {
+			eds := &datadoghqv1alpha1.ExtendedDaemonSet{}
+			Expect(k8sClient.Get(ctx, key, eds)).Should(Succeed())
+			eds.Annotations["extendeddaemonset.datadoghq.com/rollout-frozen"] = "true" // Freeze the rollout again
+			Expect(k8sClient.Update(ctx, eds)).Should(Succeed())
+
+			eds = &datadoghqv1alpha1.ExtendedDaemonSet{}
+			Eventually(withEDS(key, eds, func() bool {
+				return eds.Status.State == datadoghqv1alpha1.ExtendedDaemonSetStatusStateRolloutFrozen
+			}), timeout, interval).Should(BeTrue(), func() string {
+				return fmt.Sprintf(
+					"EDS should be updated: %#v",
+					eds.Status,
+				)
+			},
+			)
+
+			extraNode := testutils.NewNode(fmt.Sprintf("node%d", fakeNodesCount+1), nil)
+			Expect(k8sClient.Create(context.Background(), extraNode)).Should(Succeed())
+
+			ers := &datadoghqv1alpha1.ExtendedDaemonSetReplicaSet{}
+			erskey := types.NamespacedName{
+				Namespace: namespace,
+				Name:      eds.Status.ActiveReplicaSet,
+			}
+
+			Eventually(withERS(erskey, ers, func() bool {
+				expectedStatus := ers.Status.Status == string(strategy.ReplicaSetStatusActive)
+				expectedCondition := conditions.IsConditionTrue(&ers.Status, datadoghqv1alpha1.ConditionTypeRolloutFrozen)
+
+				return expectedStatus && expectedCondition
+			}), timeout, interval).Should(BeTrue(), func() string {
+				return fmt.Sprintf(
+					"ERS status should be updated: %#v",
+					ers.Status,
+				)
+			},
+			)
+
+			podList := &corev1.PodList{}
+			listOptions := []client.ListOption{
+				client.InNamespace(namespace),
+				client.MatchingLabels{
+					"extendeddaemonset.datadoghq.com/name": name,
+				},
+			}
+			Eventually(withList(listOptions, podList, "pods", func() bool {
+				return len(podList.Items) == fakeNodesCount
+			}), timeout, interval).Should(BeTrue(), func() string {
+				return fmt.Sprintf(
+					"Should not get all the pods, got: %d",
+					len(podList.Items),
+				)
+			},
+			)
+
+			Expect(k8sClient.Delete(context.Background(), extraNode)).Should(Succeed())
 		})
 	})
 })

--- a/controllers/extendeddaemonsetreplicaset/controller.go
+++ b/controllers/extendeddaemonsetreplicaset/controller.go
@@ -204,9 +204,8 @@ func (r *Reconciler) applyStrategy(logger logr.Logger, daemonset *datadoghqv1alp
 	switch strategy.ReplicaSetStatus(strategyParams.ReplicaSetStatus) {
 	case strategy.ReplicaSetStatusActive:
 		logger.Info("manage deployment")
-		conditions.UpdateExtendedDaemonSetReplicaSetStatusCondition(strategyParams.NewStatus, now, datadoghqv1alpha1.ConditionTypeActive, corev1.ConditionTrue, "", "", false, false)
 		conditions.UpdateExtendedDaemonSetReplicaSetStatusCondition(strategyParams.NewStatus, now, datadoghqv1alpha1.ConditionTypeCanary, corev1.ConditionFalse, "", "", false, false)
-		strategyResult, err = strategy.ManageDeployment(r.client, strategyParams)
+		strategyResult, err = strategy.ManageDeployment(r.client, daemonset, strategyParams)
 	case strategy.ReplicaSetStatusCanary:
 		conditions.UpdateExtendedDaemonSetReplicaSetStatusCondition(strategyParams.NewStatus, now, datadoghqv1alpha1.ConditionTypeCanary, corev1.ConditionTrue, "", "", false, false)
 		conditions.UpdateExtendedDaemonSetReplicaSetStatusCondition(strategyParams.NewStatus, now, datadoghqv1alpha1.ConditionTypeActive, corev1.ConditionFalse, "", "", false, false)

--- a/controllers/extendeddaemonsetreplicaset/strategy/rollingupdate.go
+++ b/controllers/extendeddaemonsetreplicaset/strategy/rollingupdate.go
@@ -16,6 +16,7 @@ import (
 	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	datadoghqv1alpha1 "github.com/DataDog/extendeddaemonset/api/v1alpha1"
+	eds "github.com/DataDog/extendeddaemonset/controllers/extendeddaemonset"
 	"github.com/DataDog/extendeddaemonset/controllers/extendeddaemonsetreplicaset/conditions"
 	"github.com/DataDog/extendeddaemonset/controllers/extendeddaemonsetreplicaset/strategy/limits"
 	"github.com/DataDog/extendeddaemonset/pkg/controller/utils"
@@ -27,15 +28,22 @@ import (
 const cleanCanaryLabelsThreshold = 5 * time.Minute
 
 // ManageDeployment used to manage ReplicaSet in rollingupdate state.
-func ManageDeployment(client runtimeclient.Client, params *Parameters) (*Result, error) {
-	result := &Result{}
+func ManageDeployment(client runtimeclient.Client, daemonset *datadoghqv1alpha1.ExtendedDaemonSet, params *Parameters) (*Result, error) {
+	now := time.Now()
+	metaNow := metav1.NewTime(now)
+	result := &Result{
+		IsPaused: eds.IsRollingUpdatePaused(daemonset.GetAnnotations()),
+		IsFrozen: eds.IsRolloutFrozen(daemonset.GetAnnotations()),
+	}
+	conditions.UpdateExtendedDaemonSetReplicaSetStatusCondition(params.NewStatus, metaNow, datadoghqv1alpha1.ConditionTypeRollingUpdatePaused, conditions.BoolToCondition(result.IsPaused), "", "", false, false)
+	conditions.UpdateExtendedDaemonSetReplicaSetStatusCondition(params.NewStatus, metaNow, datadoghqv1alpha1.ConditionTypeRolloutFrozen, conditions.BoolToCondition(result.IsFrozen), "", "", false, false)
+	conditions.UpdateExtendedDaemonSetReplicaSetStatusCondition(params.NewStatus, metaNow, datadoghqv1alpha1.ConditionTypeActive, conditions.BoolToCondition(!result.IsPaused && !result.IsFrozen), "", "", false, false)
 
-	// remove canary node if define.
+	// Remove canary nodes if defined.
 	for _, nodeName := range params.CanaryNodes {
 		delete(params.PodByNodeName, params.NodeByName[nodeName])
 	}
-	now := time.Now()
-	metaNow := metav1.NewTime(now)
+
 	var desiredPods, availablePods, readyPods, createdPods, allPods, oldAvailablePods, podsTerminating, nbIgnoredUnresponsiveNodes int32
 
 	allPodToCreate := []*NodeItem{}
@@ -117,8 +125,17 @@ func ManageDeployment(client runtimeclient.Client, params *Parameters) (*Result,
 	nbPodToCreateWithConstraint := utils.MinInt(nbPodToCreate, len(allPodToCreate))
 	params.Logger.V(1).Info("Pods actions with limits", "nbPodToDelete", nbPodToDelete, "nbPodToCreate", nbPodToCreate, "nbPodToDeleteWithConstraint", nbPodToDeleteWithConstraint, "nbPodToCreateWithConstraint", nbPodToCreateWithConstraint)
 
-	result.PodsToDelete = allPodToDelete[:nbPodToDeleteWithConstraint]
-	result.PodsToCreate = allPodToCreate[:nbPodToCreateWithConstraint]
+	// When paused, we only stop deleting pods.
+	// The goal is to pause rolling out the new replicaset but also to continue creating pods
+	// if new nodes join in the meantime.
+	// When frozen, we stop both the deletion and the creation of new pods.
+	if !result.IsPaused && !result.IsFrozen {
+		result.PodsToDelete = allPodToDelete[:nbPodToDeleteWithConstraint]
+	}
+	if !result.IsFrozen {
+		result.PodsToCreate = allPodToCreate[:nbPodToCreateWithConstraint]
+	}
+
 	{
 		result.NewStatus = params.NewStatus.DeepCopy()
 		result.NewStatus.Status = string(ReplicaSetStatusActive)

--- a/controllers/extendeddaemonsetreplicaset/strategy/rollingupdate.go
+++ b/controllers/extendeddaemonsetreplicaset/strategy/rollingupdate.go
@@ -123,7 +123,15 @@ func ManageDeployment(client runtimeclient.Client, daemonset *datadoghqv1alpha1.
 	nbPodToCreate, nbPodToDelete := limits.CalculatePodToCreateAndDelete(limitParams)
 	nbPodToDeleteWithConstraint := utils.MinInt(nbPodToDelete, len(allPodToDelete))
 	nbPodToCreateWithConstraint := utils.MinInt(nbPodToCreate, len(allPodToCreate))
-	params.Logger.V(1).Info("Pods actions with limits", "nbPodToDelete", nbPodToDelete, "nbPodToCreate", nbPodToCreate, "nbPodToDeleteWithConstraint", nbPodToDeleteWithConstraint, "nbPodToCreateWithConstraint", nbPodToCreateWithConstraint)
+	params.Logger.V(1).Info(
+		"Pods actions with limits",
+		"nbPodToDelete", nbPodToDelete,
+		"nbPodToCreate", nbPodToCreate,
+		"nbPodToDeleteWithConstraint", nbPodToDeleteWithConstraint,
+		"nbPodToCreateWithConstraint", nbPodToCreateWithConstraint,
+		"isRolloutFrozen", result.IsFrozen,
+		"isRollingUpdatePaused", result.IsPaused,
+	)
 
 	// When paused, we only stop deleting pods.
 	// The goal is to pause rolling out the new replicaset but also to continue creating pods

--- a/controllers/extendeddaemonsetreplicaset/strategy/type.go
+++ b/controllers/extendeddaemonsetreplicaset/strategy/type.go
@@ -58,6 +58,8 @@ type Result struct {
 
 	UnscheduledNodesDueToResourcesConstraints []string
 
+	// IsFrozen represents frozen status of the deployment.
+	IsFrozen bool
 	// IsPaused represents paused status of the deployment.
 	IsPaused bool
 	// PausedReason provides the reason for the paused deployment.

--- a/controllers/suite_helpers_test.go
+++ b/controllers/suite_helpers_test.go
@@ -31,6 +31,19 @@ func withGet(nsName types.NamespacedName, obj client.Object, desc string, condit
 	}
 }
 
+func withList(listOptions []client.ListOption, obj client.ObjectList, desc string, condition condFn) condFn {
+	return func() bool {
+		err := k8sClient.List(context.Background(), obj, listOptions...)
+		if err != nil {
+			fmt.Fprintf(GinkgoWriter, "Failed to list %s: %v", desc, err)
+
+			return false
+		}
+
+		return condition()
+	}
+}
+
 func withEDS(nsName types.NamespacedName, eds *datadoghqv1alpha1.ExtendedDaemonSet, condition condFn) condFn {
 	return withGet(nsName, eds, "EDS", condition)
 }

--- a/pkg/plugin/extendeddaemonset.go
+++ b/pkg/plugin/extendeddaemonset.go
@@ -11,7 +11,9 @@ import (
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 
 	"github.com/DataDog/extendeddaemonset/pkg/plugin/canary"
+	"github.com/DataDog/extendeddaemonset/pkg/plugin/freeze"
 	"github.com/DataDog/extendeddaemonset/pkg/plugin/get"
+	"github.com/DataDog/extendeddaemonset/pkg/plugin/pause"
 	"github.com/DataDog/extendeddaemonset/pkg/plugin/pods"
 )
 
@@ -42,6 +44,10 @@ func NewCmdExtendedDaemonset(streams genericclioptions.IOStreams) *cobra.Command
 	cmd.AddCommand(get.NewCmdGet(streams))
 	cmd.AddCommand(get.NewCmdGetERS(streams))
 	cmd.AddCommand(pods.NewCmdPods(streams))
+	cmd.AddCommand(pause.NewCmdPause(streams))
+	cmd.AddCommand(pause.NewCmdUnpause(streams))
+	cmd.AddCommand(freeze.NewCmdFreeze(streams))
+	cmd.AddCommand(freeze.NewCmdUnfreeze(streams))
 
 	o.configFlags.AddFlags(cmd.Flags())
 

--- a/pkg/plugin/freeze/doc.go
+++ b/pkg/plugin/freeze/doc.go
@@ -1,0 +1,7 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package freeze contains freeze plugin functions.
+package freeze

--- a/pkg/plugin/freeze/rollout.go
+++ b/pkg/plugin/freeze/rollout.go
@@ -1,0 +1,200 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package freeze
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/DataDog/extendeddaemonset/api/v1alpha1"
+	"github.com/DataDog/extendeddaemonset/pkg/plugin/common"
+
+	"github.com/spf13/cobra"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type wantedStatus string
+
+const (
+	frozen   wantedStatus = "frozen"
+	unfrozen wantedStatus = "unfrozen"
+)
+
+var freezeExample = `
+	# %[1]s a rollout
+	kubectl eds %[1]s foo
+`
+
+// freezeOptions provides information required to manage ExtendedDaemonSet.
+type freezeOptions struct {
+	configFlags *genericclioptions.ConfigFlags
+	args        []string
+
+	client client.Client
+
+	genericclioptions.IOStreams
+
+	userNamespace             string
+	userExtendedDaemonSetName string
+	want                      wantedStatus
+}
+
+// newfreezeOptions provides an instance of freezeOptions with default values.
+func newfreezeOptions(streams genericclioptions.IOStreams, want wantedStatus) *freezeOptions {
+	return &freezeOptions{
+		configFlags: genericclioptions.NewConfigFlags(false),
+
+		IOStreams: streams,
+
+		want: want,
+	}
+}
+
+// NewCmdFreeze provides a cobra command wrapping freezeOptions.
+func NewCmdFreeze(streams genericclioptions.IOStreams) *cobra.Command {
+	o := newfreezeOptions(streams, frozen)
+
+	cmd := &cobra.Command{
+		Use:          "freeze-rollout [ExtendedDaemonSet name]",
+		Short:        "freeze a rollout. This blocks the creation of new pods even on new nodes",
+		Example:      fmt.Sprintf(freezeExample, "freeze-rollout"),
+		SilenceUsage: true,
+		RunE: func(c *cobra.Command, args []string) error {
+			if err := o.complete(c, args); err != nil {
+				return err
+			}
+			if err := o.validate(); err != nil {
+				return err
+			}
+
+			return o.run()
+		},
+	}
+
+	o.configFlags.AddFlags(cmd.Flags())
+
+	return cmd
+}
+
+// NewCmdUnfreeze provides a cobra command wrapping freezeOptions.
+func NewCmdUnfreeze(streams genericclioptions.IOStreams) *cobra.Command {
+	o := newfreezeOptions(streams, unfrozen)
+
+	cmd := &cobra.Command{
+		Use:          "unfreeze-rollout [ExtendedDaemonSet name]",
+		Short:        "unfreeze-rollout a frozen rollout.",
+		Example:      fmt.Sprintf(freezeExample, "unfreeze-rollout"),
+		SilenceUsage: true,
+		RunE: func(c *cobra.Command, args []string) error {
+			if err := o.complete(c, args); err != nil {
+				return err
+			}
+			if err := o.validate(); err != nil {
+				return err
+			}
+
+			return o.run()
+		},
+	}
+
+	o.configFlags.AddFlags(cmd.Flags())
+
+	return cmd
+}
+
+// complete sets all information required for processing the command.
+func (o *freezeOptions) complete(cmd *cobra.Command, args []string) error {
+	o.args = args
+	var err error
+
+	clientConfig := o.configFlags.ToRawKubeConfigLoader()
+	// Create the Client for Read/Write operations.
+	o.client, err = common.NewClient(clientConfig)
+	if err != nil {
+		return fmt.Errorf("unable to instantiate client, err: %w", err)
+	}
+
+	o.userNamespace, _, err = clientConfig.Namespace()
+	if err != nil {
+		return err
+	}
+
+	ns, err2 := cmd.Flags().GetString("namespace")
+	if err2 != nil {
+		return err
+	}
+	if ns != "" {
+		o.userNamespace = ns
+	}
+
+	if len(args) > 0 {
+		o.userExtendedDaemonSetName = args[0]
+	}
+
+	return nil
+}
+
+// validate ensures that all required arguments and flag values are provided.
+func (o *freezeOptions) validate() error {
+	if len(o.args) < 1 {
+		return fmt.Errorf("the extendeddaemonset name is required")
+	}
+
+	return nil
+}
+
+// run used to run the command.
+func (o *freezeOptions) run() error {
+	eds := &v1alpha1.ExtendedDaemonSet{}
+	err := o.client.Get(context.TODO(), client.ObjectKey{Namespace: o.userNamespace, Name: o.userExtendedDaemonSetName}, eds)
+	if err != nil && errors.IsNotFound(err) {
+		return fmt.Errorf("ExtendedDaemonSet %s/%s not found", o.userNamespace, o.userExtendedDaemonSetName)
+	} else if err != nil {
+		return fmt.Errorf("unable to get ExtendedDaemonSet, err: %w", err)
+	}
+
+	if eds.Status.Canary != nil {
+		return fmt.Errorf("cannot freeze rollout: the ExtendedDaemonset has an active canary deployment. You should either fail or validate the canary first")
+	}
+
+	newEds := eds.DeepCopy()
+
+	if newEds.Annotations == nil {
+		newEds.Annotations = make(map[string]string)
+	}
+
+	isFrozen, found := newEds.Annotations[v1alpha1.ExtendedDaemonSetRolloutFrozenAnnotationKey]
+	if o.want == frozen && isFrozen == v1alpha1.ValueStringTrue {
+		// One case where freezing is impossible:
+		// - EDS is already frozen
+		return fmt.Errorf("rollout already frozen")
+	}
+	if o.want == unfrozen && (isFrozen == v1alpha1.ValueStringFalse || !found) {
+		// Two cases where unfreezing is impossible:
+		// - EDS is already unfrozen
+		// - EDS was never frozen (freeze annotation not found)
+		return fmt.Errorf("rollout is not frozen; cannot unfreeze")
+	}
+
+	// Set appropriate annotation depending on whether cmd is to freeze or unfreeze
+	switch o.want {
+	case frozen:
+		newEds.Annotations[v1alpha1.ExtendedDaemonSetRolloutFrozenAnnotationKey] = v1alpha1.ValueStringTrue
+	case unfrozen:
+		newEds.Annotations[v1alpha1.ExtendedDaemonSetRolloutFrozenAnnotationKey] = v1alpha1.ValueStringFalse
+	}
+
+	patch := client.MergeFrom(eds)
+	if err = o.client.Patch(context.TODO(), newEds, patch); err != nil {
+		return fmt.Errorf("unable to %s ExtendedDaemonset, err: %w", o.want, err)
+	}
+
+	fmt.Fprintf(o.Out, "ExtendedDaemonset '%s/%s' rollout is now %s\n", o.userNamespace, o.userExtendedDaemonSetName, o.want)
+
+	return nil
+}

--- a/pkg/plugin/pause/doc.go
+++ b/pkg/plugin/pause/doc.go
@@ -1,0 +1,7 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package pause contains pause plugin functions.
+package pause

--- a/pkg/plugin/pause/rollingupdate.go
+++ b/pkg/plugin/pause/rollingupdate.go
@@ -1,0 +1,200 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package pause
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/DataDog/extendeddaemonset/api/v1alpha1"
+	"github.com/DataDog/extendeddaemonset/pkg/plugin/common"
+
+	"github.com/spf13/cobra"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type wantedStatus string
+
+const (
+	paused   wantedStatus = "paused"
+	unpaused wantedStatus = "unpaused"
+)
+
+var pauseExample = `
+	# %[1]s an active rolling update
+	kubectl eds %[1]s foo
+`
+
+// pauseOptions provides information required to manage ExtendedDaemonSet.
+type pauseOptions struct {
+	configFlags *genericclioptions.ConfigFlags
+	args        []string
+
+	client client.Client
+
+	genericclioptions.IOStreams
+
+	userNamespace             string
+	userExtendedDaemonSetName string
+	want                      wantedStatus
+}
+
+// newPauseOptions provides an instance of GetOptions with default values.
+func newPauseOptions(streams genericclioptions.IOStreams, want wantedStatus) *pauseOptions {
+	return &pauseOptions{
+		configFlags: genericclioptions.NewConfigFlags(false),
+
+		IOStreams: streams,
+
+		want: want,
+	}
+}
+
+// NewCmdPause provides a cobra command wrapping pauseOptions.
+func NewCmdPause(streams genericclioptions.IOStreams) *cobra.Command {
+	o := newPauseOptions(streams, paused)
+
+	cmd := &cobra.Command{
+		Use:          "pause-rolling-update [ExtendedDaemonSet name]",
+		Short:        "pause a rolling update. This will not block the creation of new pods if new nodes appear or if it's the deployment of the first replicaset",
+		Example:      fmt.Sprintf(pauseExample, "pause-rolling-update"),
+		SilenceUsage: true,
+		RunE: func(c *cobra.Command, args []string) error {
+			if err := o.complete(c, args); err != nil {
+				return err
+			}
+			if err := o.validate(); err != nil {
+				return err
+			}
+
+			return o.run()
+		},
+	}
+
+	o.configFlags.AddFlags(cmd.Flags())
+
+	return cmd
+}
+
+// NewCmdUnpause provides a cobra command wrapping pauseOptions.
+func NewCmdUnpause(streams genericclioptions.IOStreams) *cobra.Command {
+	o := newPauseOptions(streams, unpaused)
+
+	cmd := &cobra.Command{
+		Use:          "unpause-rolling-update [ExtendedDaemonSet name]",
+		Short:        "unpause a paused rolling update.",
+		Example:      fmt.Sprintf(pauseExample, "unpause-rolling-update"),
+		SilenceUsage: true,
+		RunE: func(c *cobra.Command, args []string) error {
+			if err := o.complete(c, args); err != nil {
+				return err
+			}
+			if err := o.validate(); err != nil {
+				return err
+			}
+
+			return o.run()
+		},
+	}
+
+	o.configFlags.AddFlags(cmd.Flags())
+
+	return cmd
+}
+
+// complete sets all information required for processing the command.
+func (o *pauseOptions) complete(cmd *cobra.Command, args []string) error {
+	o.args = args
+	var err error
+
+	clientConfig := o.configFlags.ToRawKubeConfigLoader()
+	// Create the Client for Read/Write operations.
+	o.client, err = common.NewClient(clientConfig)
+	if err != nil {
+		return fmt.Errorf("unable to instantiate client, err: %w", err)
+	}
+
+	o.userNamespace, _, err = clientConfig.Namespace()
+	if err != nil {
+		return err
+	}
+
+	ns, err2 := cmd.Flags().GetString("namespace")
+	if err2 != nil {
+		return err
+	}
+	if ns != "" {
+		o.userNamespace = ns
+	}
+
+	if len(args) > 0 {
+		o.userExtendedDaemonSetName = args[0]
+	}
+
+	return nil
+}
+
+// validate ensures that all required arguments and flag values are provided.
+func (o *pauseOptions) validate() error {
+	if len(o.args) < 1 {
+		return fmt.Errorf("the extendeddaemonset name is required")
+	}
+
+	return nil
+}
+
+// run used to run the command.
+func (o *pauseOptions) run() error {
+	eds := &v1alpha1.ExtendedDaemonSet{}
+	err := o.client.Get(context.TODO(), client.ObjectKey{Namespace: o.userNamespace, Name: o.userExtendedDaemonSetName}, eds)
+	if err != nil && errors.IsNotFound(err) {
+		return fmt.Errorf("ExtendedDaemonSet %s/%s not found", o.userNamespace, o.userExtendedDaemonSetName)
+	} else if err != nil {
+		return fmt.Errorf("unable to get ExtendedDaemonSet, err: %w", err)
+	}
+
+	if eds.Status.Canary != nil {
+		return fmt.Errorf("cannot pause rolling update: the ExtendedDaemonset has an active canary deployment. You can use the canary pause command instead")
+	}
+
+	newEds := eds.DeepCopy()
+
+	if newEds.Annotations == nil {
+		newEds.Annotations = make(map[string]string)
+	}
+
+	isPaused, found := newEds.Annotations[v1alpha1.ExtendedDaemonSetRollingUpdatePausedAnnotationKey]
+	if o.want == paused && isPaused == v1alpha1.ValueStringTrue {
+		// One case where pausing is impossible:
+		// - EDS is already paused
+		return fmt.Errorf("rolling update already paused")
+	}
+	if o.want == unpaused && (isPaused == v1alpha1.ValueStringFalse || !found) {
+		// Two cases where unpausing is impossible:
+		// - EDS is already unpaused
+		// - EDS was never paused (pause annotation not found)
+		return fmt.Errorf("rolling update is not paused; cannot unpause")
+	}
+
+	// Set appropriate annotation depending on whether cmd is to pause or unpause
+	switch o.want {
+	case paused:
+		newEds.Annotations[v1alpha1.ExtendedDaemonSetRollingUpdatePausedAnnotationKey] = v1alpha1.ValueStringTrue
+	case unpaused:
+		newEds.Annotations[v1alpha1.ExtendedDaemonSetRollingUpdatePausedAnnotationKey] = v1alpha1.ValueStringFalse
+	}
+
+	patch := client.MergeFrom(eds)
+	if err = o.client.Patch(context.TODO(), newEds, patch); err != nil {
+		return fmt.Errorf("unable to %s ExtendedDaemonset, err: %w", o.want, err)
+	}
+
+	fmt.Fprintf(o.Out, "ExtendedDaemonset '%s/%s' rolling update is now %s\n", o.userNamespace, o.userExtendedDaemonSetName, o.want)
+
+	return nil
+}


### PR DESCRIPTION
### What does this PR do?

- Support pausing rolling updates.
  - kubectl plugin commands:
    - `k eds pause-rolling-update <eds name>` 
    - `k eds unpause-rolling-update <eds name>` 
  - When paused:
    - The replicaset controller won't delete pods anymore which prevents the rolling update from proceeding
    - The controller won't block the creation of new pods, so if new nodes appear in the meantime the controller will create new pods on the new nodes even when paused
    - Pausing a rolling update when the ERS is deployed for the first time in the cluster will not have any effect (just like canary)
    - The metric `eds_status_rolling_update_paused` is set to `1`

- Support freezing rollouts.
  - kubectl plugin commands:
    - `k eds freeze-rollout <eds name>` 
    - `k eds unfreeze-rollout <eds name>` 
  - When frozen:
    - The replicaset controller won't delete nor create new pods
    - The controller will block the creation of new pods, so if new nodes appear in the meantime the controller will not create new pods
    - Freezing a rollout will take effect even if the ERS is deployed for the first time in the cluster
    - The metric `eds_status_rollout_frozen` is set to `1`
 
### Motivation

More flexibility and better control of the EDS when deploying new changes

### Additional Notes

Make sure you build the kubectl plugin locally during QA `make kubectl-eds` -> `./bin/kubectl-eds`

### Describe your test plan

- Make sure the described behaviour above is respected
- Make sure the EDS state is updated accordingly in each case
- Make sure the ERS conditions are updated accordingly in each case
- Make sure the metrics are updated accordingly
- Make sure the kubectl plugin commands don't succeed when in canary phase
- Try edge cases like freezing and pausing at the same time, make sure the freeze wins
- Be imaginative and break the feature! 🔨 
