### PR TITLE
Fix how EDS is using the kube-scheduler when possible

### DIFF
--- a/controllers/extendeddaemonset_test.go
+++ b/controllers/extendeddaemonset_test.go
@@ -44,7 +44,7 @@ var _ = Describe("ExtendedDaemonSet Controller", func() {
 			Name:      name,
 		}
 
-		It("Should create one pod by nodes", func() {
+		It("Should create one pod by node", func() {
 			edsOptions := &testutils.NewExtendedDaemonsetOptions{
 				CanaryStrategy: nil,
 				RollingUpdate: &datadoghqv1alpha1.ExtendedDaemonSetSpecStrategyRollingUpdate{

--- a/controllers/extendeddaemonset_test.go
+++ b/controllers/extendeddaemonset_test.go
@@ -44,7 +44,7 @@ var _ = Describe("ExtendedDaemonSet Controller", func() {
 			Name:      name,
 		}
 
-		It("Should create one pod by nods", func() {
+		It("Should create one pod by nodes", func() {
 			edsOptions := &testutils.NewExtendedDaemonsetOptions{
 				CanaryStrategy: nil,
 				RollingUpdate: &datadoghqv1alpha1.ExtendedDaemonSetSpecStrategyRollingUpdate{

--- a/controllers/extendeddaemonsetreplicaset/filters.go
+++ b/controllers/extendeddaemonsetreplicaset/filters.go
@@ -74,8 +74,6 @@ func FilterAndMapPodsByNode(logger logr.Logger, replicaset *datadoghqv1alpha1.Ex
 
 			if _, scheduled := podutils.IsPodScheduled(&pod); !scheduled {
 				unscheduledPods = append(unscheduledPods, &podList.Items[id])
-
-				continue
 			}
 		} else {
 			if _, ok := ignoreMapNode[nodeName]; ok {
@@ -106,10 +104,7 @@ func FilterAndMapPodsByNode(logger logr.Logger, replicaset *datadoghqv1alpha1.Ex
 
 	// add duplicated pods to the pod deletion slice
 	for _, pod := range duplicatedPods {
-		nodeName, err := podutils.GetNodeNameFromPod(pod)
-		if err != nil {
-			continue
-		}
+		nodeName, _ := podutils.GetNodeNameFromPod(pod)
 		logger.V(1).Info("PodToDelete", "reason", "duplicatedPod", "pod.Name", pod.Name, "node.Name", nodeName)
 	}
 	podToDelete = append(podToDelete, duplicatedPods...)

--- a/pkg/controller/utils/pod/create.go
+++ b/pkg/controller/utils/pod/create.go
@@ -58,10 +58,10 @@ func CreatePodFromDaemonSetReplicaSet(scheme *runtime.Scheme, replicaset *datado
 		Spec:       templateCopy.Spec,
 	}
 	if node != nil {
-		pod.Spec.NodeName = node.Name
-
 		if addNodeAffinity {
 			pod.Spec.Affinity = affinity.ReplaceNodeNameNodeAffinity(pod.Spec.Affinity, node.Name)
+		} else {
+			pod.Spec.NodeName = node.Name
 		}
 	}
 

--- a/pkg/controller/utils/pod/pod.go
+++ b/pkg/controller/utils/pod/pod.go
@@ -6,6 +6,7 @@
 package pod
 
 import (
+	"fmt"
 	"sort"
 	"time"
 
@@ -60,6 +61,20 @@ func IsPodAvailable(pod *v1.Pod, minReadySeconds int32, now metav1.Time) bool {
 	}
 
 	return false
+}
+
+// GetNodeNameFromPod returns the NodeName from Pod spec. either from `pod.Spec.NodeName`
+// if the pod is already scheduled, of from the NodeAffinity.
+func GetNodeNameFromPod(pod *v1.Pod) (string, error) {
+	if pod.Spec.NodeName != "" {
+		return pod.Spec.NodeName, nil
+	}
+	nodeName := affinity.GetNodeNameFromAffinity(pod.Spec.Affinity)
+	if nodeName == "" {
+		return "", fmt.Errorf("unable to retrieve nodeName for the pod: %s/%s", pod.Namespace, pod.Name)
+	}
+
+	return nodeName, nil
 }
 
 // IsPodReady returns true if a pod is ready; false otherwise.


### PR DESCRIPTION
### What does this PR do?

* Fix how the ExtendedDaemonset controller is setting the `pod.Spec.NodeName` even if the `Node` affinity is used.
* Unscheduled Pod are now also assign to Node.

### Motivation

Depending of the kubernetes version (<= 1.12), the Daemonset controller is not using the kube-scheduler to schedule a Pod on a specific Node. Instead it set directly the `nodeName` in the pod spec.
Extendeddaemonset is doing the same thing. But a bug was still setting the `nodeName` even if "node affinity" was used.

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan


