### PR TITLE
Delete failed pods with a backoff

### DIFF
--- a/controllers/extendeddaemonsetreplicaset/controller.go
+++ b/controllers/extendeddaemonsetreplicaset/controller.go
@@ -167,8 +167,9 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	err = r.updateReplicaSet(replicaSetInstance, newStatus)
 
 	// Garbage collect the failedPodsBackOff map once per minute,
-	// i.e. whenever the seconds [0,60] is less than the reconcile frequency
+	// i.e. whenever the seconds [0,59] is less than the reconcile frequency
 	if now.Time.Second() < int(daemonsetInstance.Spec.Strategy.ReconcileFrequency.Duration.Seconds()) {
+		// Garbage collect records that have aged past the maxDuration (here: 15min)
 		r.failedPodsBackOff.GC()
 	}
 

--- a/controllers/extendeddaemonsetreplicaset/controller_test.go
+++ b/controllers/extendeddaemonsetreplicaset/controller_test.go
@@ -17,9 +17,11 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/clock"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/util/flowcontrol"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -160,10 +162,11 @@ func TestReconcileExtendedDaemonSetReplicaSet_Reconcile(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			r := &Reconciler{
-				client:   tt.fields.client,
-				scheme:   tt.fields.scheme,
-				recorder: tt.fields.recorder,
-				log:      testLogger,
+				client:            tt.fields.client,
+				scheme:            tt.fields.scheme,
+				recorder:          tt.fields.recorder,
+				failedPodsBackOff: flowcontrol.NewFakeBackOff(30*time.Second, 15*time.Minute, clock.NewFakeClock(time.Now())),
+				log:               testLogger,
 			}
 			got, err := r.Reconcile(context.TODO(), tt.args.request)
 			if (err != nil) != tt.wantErr {
@@ -356,9 +359,10 @@ func TestReconcileExtendedDaemonSetReplicaSet_getPodList(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			r := &Reconciler{
-				client:   tt.fields.client,
-				scheme:   tt.fields.scheme,
-				recorder: tt.fields.recorder,
+				client:            tt.fields.client,
+				scheme:            tt.fields.scheme,
+				recorder:          tt.fields.recorder,
+				failedPodsBackOff: flowcontrol.NewFakeBackOff(30*time.Second, 15*time.Minute, clock.NewFakeClock(time.Now())),
 			}
 			got, err := r.getPodList(tt.args.ds)
 			if (err != nil) != tt.wantErr {
@@ -432,10 +436,11 @@ func TestReconcileExtendedDaemonSetReplicaSet_getNodeList(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			r := &Reconciler{
-				client:   tt.fields.client,
-				scheme:   tt.fields.scheme,
-				recorder: tt.fields.recorder,
-				log:      testLogger,
+				client:            tt.fields.client,
+				scheme:            tt.fields.scheme,
+				recorder:          tt.fields.recorder,
+				failedPodsBackOff: flowcontrol.NewFakeBackOff(30*time.Second, 15*time.Minute, clock.NewFakeClock(time.Now())),
+				log:               testLogger,
 			}
 			got, err := r.getNodeList(eds, tt.args.replicaset)
 			if (err != nil) != tt.wantErr {
@@ -519,10 +524,11 @@ func TestReconcileExtendedDaemonSetReplicaSet_getDaemonsetOwner(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			r := &Reconciler{
-				client:   tt.fields.client,
-				scheme:   tt.fields.scheme,
-				recorder: tt.fields.recorder,
-				log:      testLogger,
+				client:            tt.fields.client,
+				scheme:            tt.fields.scheme,
+				recorder:          tt.fields.recorder,
+				failedPodsBackOff: flowcontrol.NewFakeBackOff(30*time.Second, 15*time.Minute, clock.NewFakeClock(time.Now())),
+				log:               testLogger,
 			}
 			got, err := r.getDaemonsetOwner(tt.args.replicaset)
 			if (err != nil) != tt.wantErr {
@@ -605,10 +611,11 @@ func TestReconcileExtendedDaemonSetReplicaSet_updateReplicaSet(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			r := &Reconciler{
-				client:   tt.fields.client,
-				scheme:   tt.fields.scheme,
-				recorder: tt.fields.recorder,
-				log:      testLogger,
+				client:            tt.fields.client,
+				scheme:            tt.fields.scheme,
+				recorder:          tt.fields.recorder,
+				failedPodsBackOff: flowcontrol.NewFakeBackOff(30*time.Second, 15*time.Minute, clock.NewFakeClock(time.Now())),
+				log:               testLogger,
 			}
 			if err := r.updateReplicaSet(tt.args.replicaset, tt.args.newStatus); (err != nil) != tt.wantErr {
 				t.Errorf("ReconcileExtendedDaemonSetReplicaSet.updateReplicaSet() error = %v, wantErr %v", err, tt.wantErr)


### PR DESCRIPTION
### What does this PR do?

- Removes the effect of the `ignoreEvictedPods` flag
- Instead of handling/ignoring evicted pods specifically, delete all `failed` pods with an exponential backoff by `ExtendedDaemonsetReplicaset` and `Node`

### Motivation

Better handling of evicted (and all failed) pods

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

- Start a `kind` cluster
- Build Docker image and deploy to cluster (with `make` commands)
- Apply an EDS spec with ephemeral storage requests and limits
- Create a file larger than the limit by running `bash -c 'dd if=/dev/urandom of=/noise bs=1M count=130'` on one of the pods
- The pod should be evicted and deleted right away. Run the `bash` command for the pod that replaces it (i.e. on the same node). Keep an eye on how long it takes for the `Evicted` pod to clear.
- After repeating a few times it should be clear that the `Evicted` pod takes longer to get deleted each time.
- Also try this on a Canary deployment