### PR TITLE
Fix leader election compatibility with old k8s version

### DIFF
--- a/main.go
+++ b/main.go
@@ -54,9 +54,11 @@ func init() {
 func main() {
 	var metricsAddr string
 	var enableLeaderElection bool
+	var leaderElectionResourceLock string
 	flag.StringVar(&metricsAddr, "metrics-addr", ":8080", "The address the metric endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "enable-leader-election", true,
 		"Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager.")
+	flag.StringVar(&leaderElectionResourceLock, "leader-election-resource", "configmaps", "determines which resource lock to use for leader election. option:[configmapsleases|endpointsleases|configmaps]")
 
 	// Custom flags
 	var printVersion, pprofActive bool
@@ -84,12 +86,13 @@ func main() {
 	version.PrintVersionLogs(setupLog)
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), config.ManagerOptionsWithNamespaces(setupLog, ctrl.Options{
-		Scheme:                 scheme,
-		MetricsBindAddress:     metricsAddr,
-		HealthProbeBindAddress: ":8081",
-		Port:                   9443,
-		LeaderElection:         enableLeaderElection,
-		LeaderElectionID:       "extendeddaemonset-lock",
+		Scheme:                     scheme,
+		MetricsBindAddress:         metricsAddr,
+		HealthProbeBindAddress:     ":8081",
+		Port:                       9443,
+		LeaderElection:             enableLeaderElection,
+		LeaderElectionID:           "extendeddaemonset-lock",
+		LeaderElectionResourceLock: leaderElectionResourceLock,
 	}))
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")


### PR DESCRIPTION
### What does this PR do?

In old Kubernetes version the `configmapsleases` resources doesn't
exist.
To keep the backward compatibility on old k8s version. The PR keep
the previous behavior which is using `configmaps` for managing
the leader election token.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

* Try to deploy the extendeddaemonset in a kubernetes cluster in version 1.10.
check that the controller start properly.
* Check also that the controller works on a recent k8s version.
