### PR TITLE
Fix some help messages in the EDS plugin

### DIFF
--- a/pkg/plugin/canary/fail.go
+++ b/pkg/plugin/canary/fail.go
@@ -23,8 +23,8 @@ const (
 )
 
 var failExample = `
-    # %[1]s a canary deployment
-    kubectl eds %[1]s foo
+    # fail a canary deployment
+    kubectl eds canary fail foo
 `
 
 // failOptions provides information required to manage ExtendedDaemonSet.
@@ -59,7 +59,7 @@ func newCmdFail(streams genericclioptions.IOStreams) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:          "fail [ExtendedDaemonSet name]",
 		Short:        "fail canary deployment",
-		Example:      fmt.Sprintf(failExample, "fail"),
+		Example:      failExample,
 		SilenceUsage: true,
 		RunE: func(c *cobra.Command, args []string) error {
 			if err := o.complete(c, args); err != nil {

--- a/pkg/plugin/canary/validate.go
+++ b/pkg/plugin/canary/validate.go
@@ -20,7 +20,7 @@ import (
 
 var validateExample = `
 	# validate a canary replicaset
-	%[1]s canary validate foo
+	kubectl eds canary validate foo
 `
 
 // validateOptions provides information required to manage ExtendedDaemonSet.
@@ -50,9 +50,9 @@ func newCmdValidate(streams genericclioptions.IOStreams) *cobra.Command {
 	o := newValidateOptions(streams)
 
 	cmd := &cobra.Command{
-		Use:          "validate an ExtendedDaemonSet canary replicaset",
+		Use:          "validate [ExtendedDaemonSet name]",
 		Short:        "validate canary replicaset",
-		Example:      fmt.Sprintf(validateExample, "kubectl"),
+		Example:      validateExample,
 		SilenceUsage: true,
 		RunE: func(c *cobra.Command, args []string) error {
 			if err := o.complete(c, args); err != nil {

--- a/pkg/plugin/extendeddaemonset.go
+++ b/pkg/plugin/extendeddaemonset.go
@@ -37,7 +37,7 @@ func NewCmdExtendedDaemonset(streams genericclioptions.IOStreams) *cobra.Command
 	o := NewExtendedDaemonsetOptions(streams)
 
 	cmd := &cobra.Command{
-		Use: "ExtendedDaemonset [subcommand] [flags]",
+		Use: "kubectl eds [subcommand] [flags]",
 	}
 
 	cmd.AddCommand(canary.NewCmdCanary(streams))


### PR DESCRIPTION
### What does this PR do?

Fix some help messages in the EDS plugin

### Motivation

```
$ kubectl eds canary fail --help
fail canary deployment

Usage:
  ExtendedDaemonset canary fail [ExtendedDaemonSet name] [flags]

Examples:

    # fail a canary deployment
    kubectl eds fail foo
```

instead of `kubectl eds canary fail [EDSname]`

```
$ kubectl eds canary validate --help
validate canary replicaset

Usage:
  ExtendedDaemonset canary validate an ExtendedDaemonSet canary replicaset [flags]

Examples:

	# validate a canary replicaset
	kubectl canary validate foo
```

instead of `kubectl eds canary validate [EDSname]`

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details you may have to test your PR.
