### PR TITLE
Fix EDS.status current pods

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,4 +1,4 @@
-image: golang:1.15
+image: registry.ddbuild.io/golang:1.15-buster
 variables:
   GO111MODULE: "on"
   PROJECTNAME: "extendeddaemonset"
@@ -6,6 +6,9 @@ variables:
   GOPATH: "$CI_PROJECT_DIR/.cache"
   TARGET_TAG: v$CI_PIPELINE_ID-$CI_COMMIT_SHORT_SHA
   BUILD_DOCKER_REGISTRY: "486234852809.dkr.ecr.us-east-1.amazonaws.com/ci"
+  DOCKER_REGISTRY_LOGIN_SSM_KEY: docker_hub_login
+  DOCKER_REGISTRY_PWD_SSM_KEY: docker_hub_pwd
+  DOCKER_REGISTRY_URL: docker.io
 cache: &global_cache
   key: ${CI_COMMIT_REF_SLUG}
   paths:
@@ -50,7 +53,10 @@ build_eds_image_amd64:
     GOARCH: amd64
     TARGET_IMAGE: $BUILD_DOCKER_REGISTRY/$PROJECTNAME:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-amd64
     RELEASE_IMAGE: $BUILD_DOCKER_REGISTRY/$PROJECTNAME:$CI_COMMIT_TAG-amd64
-  before_script: []
+  before_script:
+    # DockerHub login for build to limit rate limit when pulling base images
+    - DOCKER_REGISTRY_LOGIN=$(aws ssm get-parameter --region us-east-1 --name ci.extendeddaemonset.$DOCKER_REGISTRY_LOGIN_SSM_KEY --with-decryption --query "Parameter.Value" --out text)
+    - aws ssm get-parameter --region us-east-1 --name ci.extendeddaemonset.$DOCKER_REGISTRY_PWD_SSM_KEY --with-decryption --query "Parameter.Value" --out text | docker login --username "$DOCKER_REGISTRY_LOGIN" --password-stdin "$DOCKER_REGISTRY_URL"
   script:
     - IMG=$TARGET_IMAGE make docker-build-ci docker-push-ci
     - if [ -n "$CI_COMMIT_TAG" ]; then docker tag $TARGET_IMAGE $RELEASE_IMAGE && docker push $RELEASE_IMAGE; fi
@@ -63,7 +69,10 @@ build_eds_image_arm64:
     GOARCH: arm64
     TARGET_IMAGE: $BUILD_DOCKER_REGISTRY/$PROJECTNAME:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-arm64
     RELEASE_IMAGE: $BUILD_DOCKER_REGISTRY/$PROJECTNAME:$CI_COMMIT_TAG-arm64
-  before_script: []
+  before_script:
+    # DockerHub login for build to limit rate limit when pulling base images
+    - DOCKER_REGISTRY_LOGIN=$(aws ssm get-parameter --region us-east-1 --name ci.extendeddaemonset.$DOCKER_REGISTRY_LOGIN_SSM_KEY --with-decryption --query "Parameter.Value" --out text)
+    - aws ssm get-parameter --region us-east-1 --name ci.extendeddaemonset.$DOCKER_REGISTRY_PWD_SSM_KEY --with-decryption --query "Parameter.Value" --out text | docker login --username "$DOCKER_REGISTRY_LOGIN" --password-stdin "$DOCKER_REGISTRY_URL"
   script:
     - IMG=$TARGET_IMAGE make docker-build-ci docker-push-ci
     - if [ -n "$CI_COMMIT_TAG" ]; then docker tag $TARGET_IMAGE $RELEASE_IMAGE && docker push $RELEASE_IMAGE; fi
@@ -77,7 +86,10 @@ build_eds_check_image_amd64:
     GOARCH: amd64
     TARGET_IMAGE: $BUILD_DOCKER_REGISTRY/$PROJECTNAME_CHECK:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-amd64
     RELEASE_IMAGE: $BUILD_DOCKER_REGISTRY/$PROJECTNAME_CHECK:$CI_COMMIT_TAG-amd64
-  before_script: []
+  before_script:
+    # DockerHub login for build to limit rate limit when pulling base images
+    - DOCKER_REGISTRY_LOGIN=$(aws ssm get-parameter --region us-east-1 --name ci.extendeddaemonset.$DOCKER_REGISTRY_LOGIN_SSM_KEY --with-decryption --query "Parameter.Value" --out text)
+    - aws ssm get-parameter --region us-east-1 --name ci.extendeddaemonset.$DOCKER_REGISTRY_PWD_SSM_KEY --with-decryption --query "Parameter.Value" --out text | docker login --username "$DOCKER_REGISTRY_LOGIN" --password-stdin "$DOCKER_REGISTRY_URL"
   script:
     - IMG_CHECK=$TARGET_IMAGE make docker-build-check-ci docker-push-check-ci
     - if [ -n "$CI_COMMIT_TAG" ]; then docker tag $TARGET_IMAGE $RELEASE_IMAGE && docker push $RELEASE_IMAGE; fi
@@ -90,7 +102,10 @@ build_eds_check_image_arm64:
     GOARCH: arm64
     TARGET_IMAGE: $BUILD_DOCKER_REGISTRY/$PROJECTNAME_CHECK:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-arm64
     RELEASE_IMAGE: $BUILD_DOCKER_REGISTRY/$PROJECTNAME_CHECK:$CI_COMMIT_TAG-arm64
-  before_script: []
+  before_script:
+    # DockerHub login for build to limit rate limit when pulling base images
+    - DOCKER_REGISTRY_LOGIN=$(aws ssm get-parameter --region us-east-1 --name ci.extendeddaemonset.$DOCKER_REGISTRY_LOGIN_SSM_KEY --with-decryption --query "Parameter.Value" --out text)
+    - aws ssm get-parameter --region us-east-1 --name ci.extendeddaemonset.$DOCKER_REGISTRY_PWD_SSM_KEY --with-decryption --query "Parameter.Value" --out text | docker login --username "$DOCKER_REGISTRY_LOGIN" --password-stdin "$DOCKER_REGISTRY_URL"
   script:
     - IMG_CHECK=$TARGET_IMAGE make docker-build-check-ci docker-push-check-ci
     - if [ -n "$CI_COMMIT_TAG" ]; then docker tag $TARGET_IMAGE $RELEASE_IMAGE && docker push $RELEASE_IMAGE; fi

--- a/controllers/extendeddaemonset/controller.go
+++ b/controllers/extendeddaemonset/controller.go
@@ -118,7 +118,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	var activeRS *datadoghqv1alpha1.ExtendedDaemonSetReplicaSet
 	for id, rs := range replicaSetList.Items {
 		podsCounter.Ready += rs.Status.Ready
-		podsCounter.Current += rs.Status.Available
+		podsCounter.Current += rs.Status.Current
 
 		// Check if ReplicaSet is currently active
 		if rs.Name == instance.Status.ActiveReplicaSet {

--- a/pkg/plugin/canary/fail.go
+++ b/pkg/plugin/canary/fail.go
@@ -23,8 +23,8 @@ const (
 )
 
 var failExample = `
-    # %[1]s a canary deployment
-    kubectl eds %[1]s foo
+    # fail a canary deployment
+    kubectl eds canary fail foo
 `
 
 // failOptions provides information required to manage ExtendedDaemonSet.
@@ -59,7 +59,7 @@ func newCmdFail(streams genericclioptions.IOStreams) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:          "fail [ExtendedDaemonSet name]",
 		Short:        "fail canary deployment",
-		Example:      fmt.Sprintf(failExample, "fail"),
+		Example:      failExample,
 		SilenceUsage: true,
 		RunE: func(c *cobra.Command, args []string) error {
 			if err := o.complete(c, args); err != nil {

--- a/pkg/plugin/canary/validate.go
+++ b/pkg/plugin/canary/validate.go
@@ -20,7 +20,7 @@ import (
 
 var validateExample = `
 	# validate a canary replicaset
-	%[1]s canary validate foo
+	kubectl eds canary validate foo
 `
 
 // validateOptions provides information required to manage ExtendedDaemonSet.
@@ -50,9 +50,9 @@ func newCmdValidate(streams genericclioptions.IOStreams) *cobra.Command {
 	o := newValidateOptions(streams)
 
 	cmd := &cobra.Command{
-		Use:          "validate an ExtendedDaemonSet canary replicaset",
+		Use:          "validate [ExtendedDaemonSet name]",
 		Short:        "validate canary replicaset",
-		Example:      fmt.Sprintf(validateExample, "kubectl"),
+		Example:      validateExample,
 		SilenceUsage: true,
 		RunE: func(c *cobra.Command, args []string) error {
 			if err := o.complete(c, args); err != nil {

--- a/pkg/plugin/extendeddaemonset.go
+++ b/pkg/plugin/extendeddaemonset.go
@@ -37,7 +37,7 @@ func NewCmdExtendedDaemonset(streams genericclioptions.IOStreams) *cobra.Command
 	o := NewExtendedDaemonsetOptions(streams)
 
 	cmd := &cobra.Command{
-		Use: "ExtendedDaemonset [subcommand] [flags]",
+		Use: "kubectl eds [subcommand] [flags]",
 	}
 
 	cmd.AddCommand(canary.NewCmdCanary(streams))


### PR DESCRIPTION
### What does this PR do?

* Fix EDS status
* Fix gitlab-ci to avoid dockerhub rate-limit

### Motivation

the `eds.status.current` doesnt reflect the `ers.status.current`

```
➜ k get eds
NAME            DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   IGNORED UNRESPONSIVE NODES   STATUS    REASON   ACTIVE RS             CANARY RS   AGE
datadog-agent   2589      2570      2570    2570         2570                                     Running            datadog-agent-2dcrj               401d
➜ k get ers
NAME                  STATUS   DESIRED   CURRENT   READY   AVAILABLE   IGNORED UNRESPONSIVE NODES   NODE SELECTOR   AGE
datadog-agent-2dcrj   active   2589      2589      2572    2572        0                                            17d
```

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details you may have to test your PR.
