### PR TITLE
[Plugin] Compile with CGO enabled

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -187,7 +187,7 @@ vendor:
 	go mod vendor
 
 kubectl-eds: fmt vet lint
-	go build -ldflags '${LDFLAGS}' -o bin/kubectl-eds ./cmd/kubectl-eds/main.go
+	CGO_ENABLED=1 go build -ldflags '${LDFLAGS}' -o bin/kubectl-eds ./cmd/kubectl-eds/main.go
 
 check-eds: fmt vet lint
 	go build -ldflags '${LDFLAGS}' -o bin/check-eds ./cmd/check-eds/main.go


### PR DESCRIPTION
### What does this PR do?

Build the EDS plugin with CGO enabled.

### Motivation

Some environments require the CGO dns resolver for Go programs.

### Describe your test plan

The EDS plugin works fine in those environments.
