### PR TITLE
Use number of unschedulable/undeletable PODs in limits computation. Avoid blocking EDS rollout due to nodes in NotReady state

### DIFF
--- a/controllers/extendeddaemonsetreplicaset/strategy/canary_test.go
+++ b/controllers/extendeddaemonsetreplicaset/strategy/canary_test.go
@@ -58,7 +58,7 @@ var (
 	}
 )
 
-func newTestCanaryPod(name, hash string, status v1.PodStatus) *v1.Pod {
+func newTestPodOnNode(name, nodeName, hash string, status v1.PodStatus) *v1.Pod {
 	return &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
@@ -66,8 +66,15 @@ func newTestCanaryPod(name, hash string, status v1.PodStatus) *v1.Pod {
 				"extendeddaemonset.datadoghq.com/templatehash": hash,
 			},
 		},
+		Spec: v1.PodSpec{
+			NodeName: nodeName,
+		},
 		Status: status,
 	}
+}
+
+func newTestCanaryPod(name, hash string, status v1.PodStatus) *v1.Pod {
+	return newTestPodOnNode(name, "", hash, status)
 }
 
 func podTerminatedStatus(restartCount int32, reason string, time time.Time) v1.PodStatus {

--- a/controllers/extendeddaemonsetreplicaset/strategy/limits/limits.go
+++ b/controllers/extendeddaemonsetreplicaset/strategy/limits/limits.go
@@ -8,11 +8,12 @@ package limits
 
 // Parameters use to provide the parameters to the Calculation function.
 type Parameters struct {
-	NbNodes            int
-	NbPods             int
-	NbAvailablesPod    int
-	NbOldAvailablesPod int
-	NbCreatedPod       int
+	NbNodes             int
+	NbPods              int
+	NbAvailablesPod     int
+	NbOldAvailablesPod  int
+	NbCreatedPod        int
+	NbUnresponsiveNodes int
 
 	MaxPodCreation      int
 	MaxUnavailablePod   int
@@ -31,7 +32,12 @@ func CalculatePodToCreateAndDelete(params Parameters) (nbCreation, nbDeletion in
 		nbCreation = 0
 	}
 
-	nbDeletion = params.MaxUnavailablePod - (params.NbNodes - params.NbAvailablesPod - params.NbOldAvailablesPod)
+	effectiveUnresponsive := params.NbUnresponsiveNodes
+	if effectiveUnresponsive > params.MaxUnschedulablePod {
+		effectiveUnresponsive = params.MaxUnschedulablePod
+	}
+
+	nbDeletion = params.MaxUnavailablePod - (params.NbNodes - effectiveUnresponsive - params.NbAvailablesPod - params.NbOldAvailablesPod)
 	if nbDeletion < 0 {
 		nbDeletion = 0
 	}

--- a/controllers/extendeddaemonsetreplicaset/strategy/rollingupdate_test.go
+++ b/controllers/extendeddaemonsetreplicaset/strategy/rollingupdate_test.go
@@ -97,7 +97,7 @@ func TestManageDeployment(t *testing.T) {
 					},
 				},
 				PodByNodeName: map[*NodeItem]*corev1.Pod{
-					testCanaryNodes["a"]: newTestCanaryPod("foo-a", "v1", readyPodStatus),
+					testCanaryNodes["a"]: newTestPodOnNode("foo-a", "a", "v1", readyPodStatus),
 					testCanaryNodes["b"]: nil,
 				},
 			},
@@ -148,7 +148,7 @@ func TestManageDeployment(t *testing.T) {
 					},
 				},
 				PodByNodeName: map[*NodeItem]*corev1.Pod{
-					testCanaryNodes["a"]: newTestCanaryPod("foo-a", "v1", readyPodStatus),
+					testCanaryNodes["a"]: newTestPodOnNode("foo-a", "a", "v1", readyPodStatus),
 					testCanaryNodes["b"]: nil,
 				},
 			},
@@ -202,7 +202,7 @@ func TestManageDeployment(t *testing.T) {
 					},
 				},
 				PodByNodeName: map[*NodeItem]*corev1.Pod{
-					testCanaryNodes["a"]: newTestCanaryPod("foo-a", "v2", readyPodStatus),
+					testCanaryNodes["a"]: newTestPodOnNode("foo-a", "a", "v2", readyPodStatus),
 					testCanaryNodes["b"]: nil,
 				},
 			},
@@ -256,7 +256,7 @@ func TestManageDeployment(t *testing.T) {
 					},
 				},
 				PodByNodeName: map[*NodeItem]*corev1.Pod{
-					testCanaryNodes["a"]: withDeletionTimestamp(newTestCanaryPod("foo-a", "v2", readyPodStatus)),
+					testCanaryNodes["a"]: withDeletionTimestamp(newTestPodOnNode("foo-a", "a", "v2", readyPodStatus)),
 					testCanaryNodes["b"]: nil,
 				},
 			},


### PR DESCRIPTION
### What does this PR do?

Currently `nbIgnoredUnresponsiveNodes` is computed but it's not used in limits computation, preventing/slowing down EDS rollout due to Nodes in `NotReady` state.

Remove limitation on the value itself so that the EDS status/metrics is accurately reflecting the `NotReady` nodes.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Deploy previous EDS version, put the EDS in a `stuck` state by shutting down Kubelet on some nodes to reach the MaxUnavailablePod and then performing a rollout.
Deploy new version of EDS, the rollout should continue.
