### PR TITLE
[CI] Switch to helm/kind GH action

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -28,12 +28,10 @@ jobs:
       run: |
         make test
     - name: Setup kind for e2e
-      uses: engineerd/setup-kind@v0.5.0
+      uses: helm/kind-action@v1.2.0
       with:
-        version: "v0.11.1"
         config: test/cluster-kind.yaml
-        name: eds-e2e
-        wait: 600s
+        cluster_name: eds-e2e
     - name: Run e2e tests (kind cluster)
       run: |
         export PATH=$PATH:$(pwd)/bin


### PR DESCRIPTION
### What does this PR do?

Use `helm/kind-action` instead of `engineerd/setup-kind` for e2e GH actions.

### Motivation

Stability.

### Describe your test plan

E2E tests are green.
