### PR TITLE
Do not overwrite the canary duration

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -62,6 +62,7 @@ jobs:
         with:
           config: test/cluster-kind.yaml
           cluster_name: eds-e2e
+          wait: 600s
       - name: Run e2e tests - kube ${{ matrix.k8s }}
         run: |
           export PATH=$PATH:$(pwd)/bin

--- a/api/v1alpha1/extendeddaemonset_default.go
+++ b/api/v1alpha1/extendeddaemonset_default.go
@@ -160,7 +160,7 @@ func DefaultExtendedDaemonSetSpecStrategyCanary(c *ExtendedDaemonSetSpecStrategy
 	DefaultExtendedDaemonSetSpecStrategyCanaryAutoFail(c.AutoFail)
 
 	if c.NoRestartsDuration == nil && c.ValidationMode == ExtendedDaemonSetSpecStrategyCanaryValidationModeAuto {
-		c.Duration = &metav1.Duration{
+		c.NoRestartsDuration = &metav1.Duration{
 			Duration: defaultCanaryNoRestartsDuration * time.Minute,
 		}
 	}


### PR DESCRIPTION
### What does this PR do?

Do not overwrite the canary duration when defaulting the CR

### Motivation

Bug fix

### Describe your test plan

Apply this CR

```yaml
apiVersion: datadoghq.com/v1alpha1
kind: ExtendedDaemonSet
metadata:
  name: pause-containers
spec:
  strategy:
    canary:
      replicas: 2
  template:
    metadata:
      name: foo
    spec:
      containers:
      - name: daemon
        image: k8s.gcr.io/pause:3.0
```

```sh
kg eds pause-containers -ojson | jq .spec.strategy.canary.duration
"10m0s"  # not 5m0s
```