### PR TITLE
Adapt metadata validation patch for CRD v1

### DIFF
--- a/config/crd/bases/v1/datadoghq.com_extendeddaemonsetreplicasets.yaml
+++ b/config/crd/bases/v1/datadoghq.com_extendeddaemonsetreplicasets.yaml
@@ -118,6 +118,131 @@ spec:
                   metadata:
                     description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
                     type: object
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: 'Annotations is an unstructured key value map
+                          stored with a resource that may be set by external tools
+                          to store and retrieve arbitrary metadata. They are not queryable
+                          and should be preserved when modifying objects. More info:
+                          http://kubernetes.io/docs/user-guide/annotations'
+                        type: object
+                      clusterName:
+                        description: The name of the cluster which the object belongs
+                          to. This is used to distinguish resources with same name
+                          and namespace in different clusters. This field is not set
+                          anywhere right now and apiserver is going to ignore it if
+                          set in create or update request.
+                        type: string
+                      creationTimestamp:
+                        type: string
+                        format: date-time
+                        nullable: true
+                        description: |-
+                          CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.
+                          Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+                      deletionGracePeriodSeconds:
+                        description: Number of seconds allowed for this object to
+                          gracefully terminate before it will be removed from the
+                          system. Only set when deletionTimestamp is also set. May
+                          only be shortened. Read-only.
+                        format: int64
+                        type: integer
+                      deletionTimestamp:
+                        type: string
+                        description: |-
+                          DeletionTimestamp is RFC 3339 date and time at which this resource will be deleted. This field is set by the server when a graceful deletion is requested by the user, and is not directly settable by a client. The resource is expected to be deleted (no longer visible from resource lists, and not reachable by name) after the time in this field, once the finalizers list is empty. As long as the finalizers list contains items, deletion is blocked. Once the deletionTimestamp is set, this value may not be unset or be set further into the future, although it may be shortened or the resource may be deleted prior to this time. For example, a user may request that a pod is deleted in 30 seconds. The Kubelet will react by sending a graceful termination signal to the containers in the pod. After that 30 seconds, the Kubelet will send a hard termination signal (SIGKILL) to the container and after cleanup, remove the pod from the API. In the presence of network partitions, this object may still exist after this timestamp, until an administrator or automated process can determine the resource is fully terminated. If not set, graceful deletion of the object has not been requested.
+                          Populated by the system when a graceful deletion is requested. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+                      finalizers:
+                        description: Must be empty before the object is deleted from
+                          the registry. Each entry is an identifier for the responsible
+                          component that will remove the entry from the list. If the
+                          deletionTimestamp of the object is non-nil, entries in this
+                          list can only be removed. Finalizers may be processed and
+                          removed in any order.  Order is NOT enforced because it
+                          introduces significant risk of stuck finalizers. finalizers
+                          is a shared field, any actor with permission can reorder
+                          it. If the finalizer list is processed in order, then this
+                          can lead to a situation in which the component responsible
+                          for the first finalizer in the list is waiting for a signal
+                          (field value, external system, or other) produced by a component
+                          responsible for a finalizer later in the list, resulting
+                          in a deadlock. Without enforced ordering finalizers are
+                          free to order amongst themselves and are not vulnerable
+                          to ordering changes in the list.
+                        items:
+                          type: string
+                        type: array
+                      generateName:
+                        description: |-
+                          GenerateName is an optional prefix, used by the server, to generate a unique name ONLY IF the Name field has not been provided. If this field is used, the name returned to the client will be different than the name passed. This value will also be combined with a unique suffix. The provided value has the same validation rules as the Name field, and may be truncated by the length of the suffix required to make the value unique on the server.
+                          If this field is specified and the generated name exists, the server will NOT return a 409 - instead, it will either return 201 Created or 500 with Reason ServerTimeout indicating a unique name could not be found in the time allotted, and the client should retry (optionally after the time indicated in the Retry-After header).
+                          Applied only if Name is not specified. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#idempotency
+                        type: string
+                      generation:
+                        description: A sequence number representing a specific generation
+                          of the desired state. Populated by the system. Read-only.
+                        format: int64
+                        type: integer
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: 'Map of string keys and values that can be used
+                          to organize and categorize (scope and select) objects. May
+                          match selectors of replication controllers and services.
+                          More info: http://kubernetes.io/docs/user-guide/labels'
+                        type: object
+                      managedFields:
+                        description: ManagedFields maps workflow-id and version to
+                          the set of fields that are managed by that workflow. This
+                          is mostly for internal housekeeping, and users typically
+                          shouldn't need to set or understand this field. A workflow
+                          can be the user's name, a controller's name, or the name
+                          of a specific apply path like "ci-cd". The set of fields
+                          is always in the version that the workflow used when modifying
+                          the object.
+                        items:
+                          type: object
+                        type: array
+                      name:
+                        description: 'Name must be unique within a namespace. Is required
+                          when creating resources, although some resources may allow
+                          a client to request the generation of an appropriate name
+                          automatically. Name is primarily intended for creation idempotence
+                          and configuration definition. Cannot be updated. More info:
+                          http://kubernetes.io/docs/user-guide/identifiers#names'
+                        type: string
+                      namespace:
+                        description: |-
+                          Namespace defines the space within which each name must be unique. An empty namespace is equivalent to the "default" namespace, but "default" is the canonical representation. Not all objects are required to be scoped to a namespace - the value of this field for those objects will be empty.
+                          Must be a DNS_LABEL. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/namespaces
+                        type: string
+                      ownerReferences:
+                        description: List of objects depended by this object. If ALL
+                          objects in the list have been deleted, this object will
+                          be garbage collected. If this object is managed by a controller,
+                          then an entry in this list will point to this controller,
+                          with the controller field set to true. There cannot be more
+                          than one managing controller.
+                        items:
+                          type: object
+                        type: array
+                      resourceVersion:
+                        description: |-
+                          An opaque value that represents the internal version of this object that can be used by clients to determine when objects have changed. May be used for optimistic concurrency, change detection, and the watch operation on a resource or set of resources. Clients must treat these values as opaque and passed unmodified back to the server. They may only be valid for a particular resource or set of resources.
+                          Populated by the system. Read-only. Value must be treated as opaque by clients and . More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                        type: string
+                      selfLink:
+                        description: |-
+                          SelfLink is a URL representing this object. Populated by the system. Read-only.
+                          DEPRECATED Kubernetes will stop propagating this field in 1.20 release and the field is planned to be removed in 1.21 release.
+                        type: string
+                      uid:
+                        description: |-
+                          UID is the unique in time and space value for this object. It is typically generated by the server on successful creation of a resource and is not allowed to change on PUT operations.
+                          Populated by the system. Read-only. More info: http://kubernetes.io/docs/user-guide/identifiers#uids
+                        type: string
                   spec:
                     description: 'Specification of the desired behavior of the pod.
                       More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
@@ -6433,139 +6558,6 @@ spec:
     storage: true
     subresources:
       status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        spec:
-          properties:
-            template:
-              properties:
-                metadata:
-                  description: ObjectMeta is metadata that all persisted resources
-                    must have, which includes all objects users must create.
-                  properties:
-                    annotations:
-                      additionalProperties:
-                        type: string
-                      description: 'Annotations is an unstructured key value map stored
-                        with a resource that may be set by external tools to store
-                        and retrieve arbitrary metadata. They are not queryable and
-                        should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations'
-                      type: object
-                    clusterName:
-                      description: The name of the cluster which the object belongs
-                        to. This is used to distinguish resources with same name and
-                        namespace in different clusters. This field is not set anywhere
-                        right now and apiserver is going to ignore it if set in create
-                        or update request.
-                      type: string
-                    creationTimestamp:
-                      type: string
-                      format: date-time
-                      nullable: true
-                      description: |-
-                        CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.
-                        Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-                    deletionGracePeriodSeconds:
-                      description: Number of seconds allowed for this object to gracefully
-                        terminate before it will be removed from the system. Only
-                        set when deletionTimestamp is also set. May only be shortened.
-                        Read-only.
-                      format: int64
-                      type: integer
-                    deletionTimestamp:
-                      type: string
-                      description: |-
-                        DeletionTimestamp is RFC 3339 date and time at which this resource will be deleted. This field is set by the server when a graceful deletion is requested by the user, and is not directly settable by a client. The resource is expected to be deleted (no longer visible from resource lists, and not reachable by name) after the time in this field, once the finalizers list is empty. As long as the finalizers list contains items, deletion is blocked. Once the deletionTimestamp is set, this value may not be unset or be set further into the future, although it may be shortened or the resource may be deleted prior to this time. For example, a user may request that a pod is deleted in 30 seconds. The Kubelet will react by sending a graceful termination signal to the containers in the pod. After that 30 seconds, the Kubelet will send a hard termination signal (SIGKILL) to the container and after cleanup, remove the pod from the API. In the presence of network partitions, this object may still exist after this timestamp, until an administrator or automated process can determine the resource is fully terminated. If not set, graceful deletion of the object has not been requested.
-                        Populated by the system when a graceful deletion is requested. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-                    finalizers:
-                      description: Must be empty before the object is deleted from
-                        the registry. Each entry is an identifier for the responsible
-                        component that will remove the entry from the list. If the
-                        deletionTimestamp of the object is non-nil, entries in this
-                        list can only be removed. Finalizers may be processed and
-                        removed in any order.  Order is NOT enforced because it introduces
-                        significant risk of stuck finalizers. finalizers is a shared
-                        field, any actor with permission can reorder it. If the finalizer
-                        list is processed in order, then this can lead to a situation
-                        in which the component responsible for the first finalizer
-                        in the list is waiting for a signal (field value, external
-                        system, or other) produced by a component responsible for
-                        a finalizer later in the list, resulting in a deadlock. Without
-                        enforced ordering finalizers are free to order amongst themselves
-                        and are not vulnerable to ordering changes in the list.
-                      items:
-                        type: string
-                      type: array
-                    generateName:
-                      description: |-
-                        GenerateName is an optional prefix, used by the server, to generate a unique name ONLY IF the Name field has not been provided. If this field is used, the name returned to the client will be different than the name passed. This value will also be combined with a unique suffix. The provided value has the same validation rules as the Name field, and may be truncated by the length of the suffix required to make the value unique on the server.
-                        If this field is specified and the generated name exists, the server will NOT return a 409 - instead, it will either return 201 Created or 500 with Reason ServerTimeout indicating a unique name could not be found in the time allotted, and the client should retry (optionally after the time indicated in the Retry-After header).
-                        Applied only if Name is not specified. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#idempotency
-                      type: string
-                    generation:
-                      description: A sequence number representing a specific generation
-                        of the desired state. Populated by the system. Read-only.
-                      format: int64
-                      type: integer
-                    labels:
-                      additionalProperties:
-                        type: string
-                      description: 'Map of string keys and values that can be used
-                        to organize and categorize (scope and select) objects. May
-                        match selectors of replication controllers and services. More
-                        info: http://kubernetes.io/docs/user-guide/labels'
-                      type: object
-                    managedFields:
-                      description: ManagedFields maps workflow-id and version to the
-                        set of fields that are managed by that workflow. This is mostly
-                        for internal housekeeping, and users typically shouldn't need
-                        to set or understand this field. A workflow can be the user's
-                        name, a controller's name, or the name of a specific apply
-                        path like "ci-cd". The set of fields is always in the version
-                        that the workflow used when modifying the object.
-                      items:
-                        type: object
-                      type: array
-                    name:
-                      description: 'Name must be unique within a namespace. Is required
-                        when creating resources, although some resources may allow
-                        a client to request the generation of an appropriate name
-                        automatically. Name is primarily intended for creation idempotence
-                        and configuration definition. Cannot be updated. More info:
-                        http://kubernetes.io/docs/user-guide/identifiers#names'
-                      type: string
-                    namespace:
-                      description: |-
-                        Namespace defines the space within which each name must be unique. An empty namespace is equivalent to the "default" namespace, but "default" is the canonical representation. Not all objects are required to be scoped to a namespace - the value of this field for those objects will be empty.
-                        Must be a DNS_LABEL. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/namespaces
-                      type: string
-                    ownerReferences:
-                      description: List of objects depended by this object. If ALL
-                        objects in the list have been deleted, this object will be
-                        garbage collected. If this object is managed by a controller,
-                        then an entry in this list will point to this controller,
-                        with the controller field set to true. There cannot be more
-                        than one managing controller.
-                      items:
-                        type: object
-                      type: array
-                    resourceVersion:
-                      description: |-
-                        An opaque value that represents the internal version of this object that can be used by clients to determine when objects have changed. May be used for optimistic concurrency, change detection, and the watch operation on a resource or set of resources. Clients must treat these values as opaque and passed unmodified back to the server. They may only be valid for a particular resource or set of resources.
-                        Populated by the system. Read-only. Value must be treated as opaque by clients and . More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
-                      type: string
-                    selfLink:
-                      description: |-
-                        SelfLink is a URL representing this object. Populated by the system. Read-only.
-                        DEPRECATED Kubernetes will stop propagating this field in 1.20 release and the field is planned to be removed in 1.21 release.
-                      type: string
-                    uid:
-                      description: |-
-                        UID is the unique in time and space value for this object. It is typically generated by the server on successful creation of a resource and is not allowed to change on PUT operations.
-                        Populated by the system. Read-only. More info: http://kubernetes.io/docs/user-guide/identifiers#uids
-                      type: string
-                  type: object
 status:
   acceptedNames:
     kind: ""

--- a/config/crd/bases/v1/datadoghq.com_extendeddaemonsets.yaml
+++ b/config/crd/bases/v1/datadoghq.com_extendeddaemonsets.yaml
@@ -290,6 +290,131 @@ spec:
                   metadata:
                     description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
                     type: object
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: 'Annotations is an unstructured key value map
+                          stored with a resource that may be set by external tools
+                          to store and retrieve arbitrary metadata. They are not queryable
+                          and should be preserved when modifying objects. More info:
+                          http://kubernetes.io/docs/user-guide/annotations'
+                        type: object
+                      clusterName:
+                        description: The name of the cluster which the object belongs
+                          to. This is used to distinguish resources with same name
+                          and namespace in different clusters. This field is not set
+                          anywhere right now and apiserver is going to ignore it if
+                          set in create or update request.
+                        type: string
+                      creationTimestamp:
+                        type: string
+                        format: date-time
+                        nullable: true
+                        description: |-
+                          CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.
+                          Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+                      deletionGracePeriodSeconds:
+                        description: Number of seconds allowed for this object to
+                          gracefully terminate before it will be removed from the
+                          system. Only set when deletionTimestamp is also set. May
+                          only be shortened. Read-only.
+                        format: int64
+                        type: integer
+                      deletionTimestamp:
+                        type: string
+                        description: |-
+                          DeletionTimestamp is RFC 3339 date and time at which this resource will be deleted. This field is set by the server when a graceful deletion is requested by the user, and is not directly settable by a client. The resource is expected to be deleted (no longer visible from resource lists, and not reachable by name) after the time in this field, once the finalizers list is empty. As long as the finalizers list contains items, deletion is blocked. Once the deletionTimestamp is set, this value may not be unset or be set further into the future, although it may be shortened or the resource may be deleted prior to this time. For example, a user may request that a pod is deleted in 30 seconds. The Kubelet will react by sending a graceful termination signal to the containers in the pod. After that 30 seconds, the Kubelet will send a hard termination signal (SIGKILL) to the container and after cleanup, remove the pod from the API. In the presence of network partitions, this object may still exist after this timestamp, until an administrator or automated process can determine the resource is fully terminated. If not set, graceful deletion of the object has not been requested.
+                          Populated by the system when a graceful deletion is requested. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+                      finalizers:
+                        description: Must be empty before the object is deleted from
+                          the registry. Each entry is an identifier for the responsible
+                          component that will remove the entry from the list. If the
+                          deletionTimestamp of the object is non-nil, entries in this
+                          list can only be removed. Finalizers may be processed and
+                          removed in any order.  Order is NOT enforced because it
+                          introduces significant risk of stuck finalizers. finalizers
+                          is a shared field, any actor with permission can reorder
+                          it. If the finalizer list is processed in order, then this
+                          can lead to a situation in which the component responsible
+                          for the first finalizer in the list is waiting for a signal
+                          (field value, external system, or other) produced by a component
+                          responsible for a finalizer later in the list, resulting
+                          in a deadlock. Without enforced ordering finalizers are
+                          free to order amongst themselves and are not vulnerable
+                          to ordering changes in the list.
+                        items:
+                          type: string
+                        type: array
+                      generateName:
+                        description: |-
+                          GenerateName is an optional prefix, used by the server, to generate a unique name ONLY IF the Name field has not been provided. If this field is used, the name returned to the client will be different than the name passed. This value will also be combined with a unique suffix. The provided value has the same validation rules as the Name field, and may be truncated by the length of the suffix required to make the value unique on the server.
+                          If this field is specified and the generated name exists, the server will NOT return a 409 - instead, it will either return 201 Created or 500 with Reason ServerTimeout indicating a unique name could not be found in the time allotted, and the client should retry (optionally after the time indicated in the Retry-After header).
+                          Applied only if Name is not specified. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#idempotency
+                        type: string
+                      generation:
+                        description: A sequence number representing a specific generation
+                          of the desired state. Populated by the system. Read-only.
+                        format: int64
+                        type: integer
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: 'Map of string keys and values that can be used
+                          to organize and categorize (scope and select) objects. May
+                          match selectors of replication controllers and services.
+                          More info: http://kubernetes.io/docs/user-guide/labels'
+                        type: object
+                      managedFields:
+                        description: ManagedFields maps workflow-id and version to
+                          the set of fields that are managed by that workflow. This
+                          is mostly for internal housekeeping, and users typically
+                          shouldn't need to set or understand this field. A workflow
+                          can be the user's name, a controller's name, or the name
+                          of a specific apply path like "ci-cd". The set of fields
+                          is always in the version that the workflow used when modifying
+                          the object.
+                        items:
+                          type: object
+                        type: array
+                      name:
+                        description: 'Name must be unique within a namespace. Is required
+                          when creating resources, although some resources may allow
+                          a client to request the generation of an appropriate name
+                          automatically. Name is primarily intended for creation idempotence
+                          and configuration definition. Cannot be updated. More info:
+                          http://kubernetes.io/docs/user-guide/identifiers#names'
+                        type: string
+                      namespace:
+                        description: |-
+                          Namespace defines the space within which each name must be unique. An empty namespace is equivalent to the "default" namespace, but "default" is the canonical representation. Not all objects are required to be scoped to a namespace - the value of this field for those objects will be empty.
+                          Must be a DNS_LABEL. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/namespaces
+                        type: string
+                      ownerReferences:
+                        description: List of objects depended by this object. If ALL
+                          objects in the list have been deleted, this object will
+                          be garbage collected. If this object is managed by a controller,
+                          then an entry in this list will point to this controller,
+                          with the controller field set to true. There cannot be more
+                          than one managing controller.
+                        items:
+                          type: object
+                        type: array
+                      resourceVersion:
+                        description: |-
+                          An opaque value that represents the internal version of this object that can be used by clients to determine when objects have changed. May be used for optimistic concurrency, change detection, and the watch operation on a resource or set of resources. Clients must treat these values as opaque and passed unmodified back to the server. They may only be valid for a particular resource or set of resources.
+                          Populated by the system. Read-only. Value must be treated as opaque by clients and . More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                        type: string
+                      selfLink:
+                        description: |-
+                          SelfLink is a URL representing this object. Populated by the system. Read-only.
+                          DEPRECATED Kubernetes will stop propagating this field in 1.20 release and the field is planned to be removed in 1.21 release.
+                        type: string
+                      uid:
+                        description: |-
+                          UID is the unique in time and space value for this object. It is typically generated by the server on successful creation of a resource and is not allowed to change on PUT operations.
+                          Populated by the system. Read-only. More info: http://kubernetes.io/docs/user-guide/identifiers#uids
+                        type: string
                   spec:
                     description: 'Specification of the desired behavior of the pod.
                       More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
@@ -6626,139 +6751,6 @@ spec:
     storage: true
     subresources:
       status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        spec:
-          properties:
-            template:
-              properties:
-                metadata:
-                  description: ObjectMeta is metadata that all persisted resources
-                    must have, which includes all objects users must create.
-                  properties:
-                    annotations:
-                      additionalProperties:
-                        type: string
-                      description: 'Annotations is an unstructured key value map stored
-                        with a resource that may be set by external tools to store
-                        and retrieve arbitrary metadata. They are not queryable and
-                        should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations'
-                      type: object
-                    clusterName:
-                      description: The name of the cluster which the object belongs
-                        to. This is used to distinguish resources with same name and
-                        namespace in different clusters. This field is not set anywhere
-                        right now and apiserver is going to ignore it if set in create
-                        or update request.
-                      type: string
-                    creationTimestamp:
-                      type: string
-                      format: date-time
-                      nullable: true
-                      description: |-
-                        CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.
-                        Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-                    deletionGracePeriodSeconds:
-                      description: Number of seconds allowed for this object to gracefully
-                        terminate before it will be removed from the system. Only
-                        set when deletionTimestamp is also set. May only be shortened.
-                        Read-only.
-                      format: int64
-                      type: integer
-                    deletionTimestamp:
-                      type: string
-                      description: |-
-                        DeletionTimestamp is RFC 3339 date and time at which this resource will be deleted. This field is set by the server when a graceful deletion is requested by the user, and is not directly settable by a client. The resource is expected to be deleted (no longer visible from resource lists, and not reachable by name) after the time in this field, once the finalizers list is empty. As long as the finalizers list contains items, deletion is blocked. Once the deletionTimestamp is set, this value may not be unset or be set further into the future, although it may be shortened or the resource may be deleted prior to this time. For example, a user may request that a pod is deleted in 30 seconds. The Kubelet will react by sending a graceful termination signal to the containers in the pod. After that 30 seconds, the Kubelet will send a hard termination signal (SIGKILL) to the container and after cleanup, remove the pod from the API. In the presence of network partitions, this object may still exist after this timestamp, until an administrator or automated process can determine the resource is fully terminated. If not set, graceful deletion of the object has not been requested.
-                        Populated by the system when a graceful deletion is requested. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-                    finalizers:
-                      description: Must be empty before the object is deleted from
-                        the registry. Each entry is an identifier for the responsible
-                        component that will remove the entry from the list. If the
-                        deletionTimestamp of the object is non-nil, entries in this
-                        list can only be removed. Finalizers may be processed and
-                        removed in any order.  Order is NOT enforced because it introduces
-                        significant risk of stuck finalizers. finalizers is a shared
-                        field, any actor with permission can reorder it. If the finalizer
-                        list is processed in order, then this can lead to a situation
-                        in which the component responsible for the first finalizer
-                        in the list is waiting for a signal (field value, external
-                        system, or other) produced by a component responsible for
-                        a finalizer later in the list, resulting in a deadlock. Without
-                        enforced ordering finalizers are free to order amongst themselves
-                        and are not vulnerable to ordering changes in the list.
-                      items:
-                        type: string
-                      type: array
-                    generateName:
-                      description: |-
-                        GenerateName is an optional prefix, used by the server, to generate a unique name ONLY IF the Name field has not been provided. If this field is used, the name returned to the client will be different than the name passed. This value will also be combined with a unique suffix. The provided value has the same validation rules as the Name field, and may be truncated by the length of the suffix required to make the value unique on the server.
-                        If this field is specified and the generated name exists, the server will NOT return a 409 - instead, it will either return 201 Created or 500 with Reason ServerTimeout indicating a unique name could not be found in the time allotted, and the client should retry (optionally after the time indicated in the Retry-After header).
-                        Applied only if Name is not specified. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#idempotency
-                      type: string
-                    generation:
-                      description: A sequence number representing a specific generation
-                        of the desired state. Populated by the system. Read-only.
-                      format: int64
-                      type: integer
-                    labels:
-                      additionalProperties:
-                        type: string
-                      description: 'Map of string keys and values that can be used
-                        to organize and categorize (scope and select) objects. May
-                        match selectors of replication controllers and services. More
-                        info: http://kubernetes.io/docs/user-guide/labels'
-                      type: object
-                    managedFields:
-                      description: ManagedFields maps workflow-id and version to the
-                        set of fields that are managed by that workflow. This is mostly
-                        for internal housekeeping, and users typically shouldn't need
-                        to set or understand this field. A workflow can be the user's
-                        name, a controller's name, or the name of a specific apply
-                        path like "ci-cd". The set of fields is always in the version
-                        that the workflow used when modifying the object.
-                      items:
-                        type: object
-                      type: array
-                    name:
-                      description: 'Name must be unique within a namespace. Is required
-                        when creating resources, although some resources may allow
-                        a client to request the generation of an appropriate name
-                        automatically. Name is primarily intended for creation idempotence
-                        and configuration definition. Cannot be updated. More info:
-                        http://kubernetes.io/docs/user-guide/identifiers#names'
-                      type: string
-                    namespace:
-                      description: |-
-                        Namespace defines the space within which each name must be unique. An empty namespace is equivalent to the "default" namespace, but "default" is the canonical representation. Not all objects are required to be scoped to a namespace - the value of this field for those objects will be empty.
-                        Must be a DNS_LABEL. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/namespaces
-                      type: string
-                    ownerReferences:
-                      description: List of objects depended by this object. If ALL
-                        objects in the list have been deleted, this object will be
-                        garbage collected. If this object is managed by a controller,
-                        then an entry in this list will point to this controller,
-                        with the controller field set to true. There cannot be more
-                        than one managing controller.
-                      items:
-                        type: object
-                      type: array
-                    resourceVersion:
-                      description: |-
-                        An opaque value that represents the internal version of this object that can be used by clients to determine when objects have changed. May be used for optimistic concurrency, change detection, and the watch operation on a resource or set of resources. Clients must treat these values as opaque and passed unmodified back to the server. They may only be valid for a particular resource or set of resources.
-                        Populated by the system. Read-only. Value must be treated as opaque by clients and . More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
-                      type: string
-                    selfLink:
-                      description: |-
-                        SelfLink is a URL representing this object. Populated by the system. Read-only.
-                        DEPRECATED Kubernetes will stop propagating this field in 1.20 release and the field is planned to be removed in 1.21 release.
-                      type: string
-                    uid:
-                      description: |-
-                        UID is the unique in time and space value for this object. It is typically generated by the server on successful creation of a resource and is not allowed to change on PUT operations.
-                        Populated by the system. Read-only. More info: http://kubernetes.io/docs/user-guide/identifiers#uids
-                      type: string
-                  type: object
 status:
   acceptedNames:
     kind: ""

--- a/hack/patch-crd-metadata.yaml
+++ b/hack/patch-crd-metadata.yaml
@@ -1,124 +1,114 @@
-spec:
-  validation:
-    openAPIV3Schema:
-      properties:
-        spec:
-          properties:
-            template:
-              properties:
-                metadata:
-                  description: ObjectMeta is metadata that all persisted resources must have, which
-                    includes all objects users must create.
-                  properties:
-                    annotations:
-                      additionalProperties:
-                        type: string
-                      description: 'Annotations is an unstructured key value map stored with a resource
-                        that may be set by external tools to store and retrieve arbitrary metadata.
-                        They are not queryable and should be preserved when modifying objects. More
-                        info: http://kubernetes.io/docs/user-guide/annotations'
-                      type: object
-                    clusterName:
-                      description: The name of the cluster which the object belongs to. This is used
-                        to distinguish resources with same name and namespace in different clusters.
-                        This field is not set anywhere right now and apiserver is going to ignore it
-                        if set in create or update request.
-                      type: string
-                    creationTimestamp:
-                      type: string
-                      format: date-time
-                      nullable: true
-                      description: |-
-                        CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.
-                        Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-                    deletionGracePeriodSeconds:
-                      description: Number of seconds allowed for this object to gracefully terminate
-                        before it will be removed from the system. Only set when deletionTimestamp is
-                        also set. May only be shortened. Read-only.
-                      format: int64
-                      type: integer
-                    deletionTimestamp:
-                      type: string
-                      description: |-
-                        DeletionTimestamp is RFC 3339 date and time at which this resource will be deleted. This field is set by the server when a graceful deletion is requested by the user, and is not directly settable by a client. The resource is expected to be deleted (no longer visible from resource lists, and not reachable by name) after the time in this field, once the finalizers list is empty. As long as the finalizers list contains items, deletion is blocked. Once the deletionTimestamp is set, this value may not be unset or be set further into the future, although it may be shortened or the resource may be deleted prior to this time. For example, a user may request that a pod is deleted in 30 seconds. The Kubelet will react by sending a graceful termination signal to the containers in the pod. After that 30 seconds, the Kubelet will send a hard termination signal (SIGKILL) to the container and after cleanup, remove the pod from the API. In the presence of network partitions, this object may still exist after this timestamp, until an administrator or automated process can determine the resource is fully terminated. If not set, graceful deletion of the object has not been requested.
-                        Populated by the system when a graceful deletion is requested. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-                    finalizers:
-                      description: Must be empty before the object is deleted from the registry. Each
-                        entry is an identifier for the responsible component that will remove the entry
-                        from the list. If the deletionTimestamp of the object is non-nil, entries in
-                        this list can only be removed. Finalizers may be processed and removed in any
-                        order.  Order is NOT enforced because it introduces significant risk of stuck
-                        finalizers. finalizers is a shared field, any actor with permission can reorder
-                        it. If the finalizer list is processed in order, then this can lead to a situation
-                        in which the component responsible for the first finalizer in the list is waiting
-                        for a signal (field value, external system, or other) produced by a component
-                        responsible for a finalizer later in the list, resulting in a deadlock. Without
-                        enforced ordering finalizers are free to order amongst themselves and are not
-                        vulnerable to ordering changes in the list.
-                      items:
-                        type: string
-                      type: array
-                    generateName:
-                      description: |-
-                        GenerateName is an optional prefix, used by the server, to generate a unique name ONLY IF the Name field has not been provided. If this field is used, the name returned to the client will be different than the name passed. This value will also be combined with a unique suffix. The provided value has the same validation rules as the Name field, and may be truncated by the length of the suffix required to make the value unique on the server.
-                        If this field is specified and the generated name exists, the server will NOT return a 409 - instead, it will either return 201 Created or 500 with Reason ServerTimeout indicating a unique name could not be found in the time allotted, and the client should retry (optionally after the time indicated in the Retry-After header).
-                        Applied only if Name is not specified. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#idempotency
-                      type: string
-                    generation:
-                      description: A sequence number representing a specific generation of the desired
-                        state. Populated by the system. Read-only.
-                      format: int64
-                      type: integer
-                    labels:
-                      additionalProperties:
-                        type: string
-                      description: 'Map of string keys and values that can be used to organize and categorize
-                        (scope and select) objects. May match selectors of replication controllers and
-                        services. More info: http://kubernetes.io/docs/user-guide/labels'
-                      type: object
-                    managedFields:
-                      description: ManagedFields maps workflow-id and version to the set of fields that
-                        are managed by that workflow. This is mostly for internal housekeeping, and
-                        users typically shouldn't need to set or understand this field. A workflow can
-                        be the user's name, a controller's name, or the name of a specific apply path
-                        like "ci-cd". The set of fields is always in the version that the workflow used
-                        when modifying the object.
-                      items:
-                        type: object
-                      type: array
-                    name:
-                      description: 'Name must be unique within a namespace. Is required when creating
-                        resources, although some resources may allow a client to request the generation
-                        of an appropriate name automatically. Name is primarily intended for creation
-                        idempotence and configuration definition. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
-                      type: string
-                    namespace:
-                      description: |-
-                        Namespace defines the space within which each name must be unique. An empty namespace is equivalent to the "default" namespace, but "default" is the canonical representation. Not all objects are required to be scoped to a namespace - the value of this field for those objects will be empty.
-                        Must be a DNS_LABEL. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/namespaces
-                      type: string
-                    ownerReferences:
-                      description: List of objects depended by this object. If ALL objects in the list
-                        have been deleted, this object will be garbage collected. If this object is
-                        managed by a controller, then an entry in this list will point to this controller,
-                        with the controller field set to true. There cannot be more than one managing
-                        controller.
-                      items:
-                        type: object
-                      type: array
-                    resourceVersion:
-                      description: |-
-                        An opaque value that represents the internal version of this object that can be used by clients to determine when objects have changed. May be used for optimistic concurrency, change detection, and the watch operation on a resource or set of resources. Clients must treat these values as opaque and passed unmodified back to the server. They may only be valid for a particular resource or set of resources.
-                        Populated by the system. Read-only. Value must be treated as opaque by clients and . More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
-                      type: string
-                    selfLink:
-                      description: |-
-                        SelfLink is a URL representing this object. Populated by the system. Read-only.
-                        DEPRECATED Kubernetes will stop propagating this field in 1.20 release and the field is planned to be removed in 1.21 release.
-                      type: string
-                    uid:
-                      description: |-
-                        UID is the unique in time and space value for this object. It is typically generated by the server on successful creation of a resource and is not allowed to change on PUT operations.
-                        Populated by the system. Read-only. More info: http://kubernetes.io/docs/user-guide/identifiers#uids
-                      type: string
-                  type: object
+description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+type: object
+properties:
+  annotations:
+    additionalProperties:
+      type: string
+    description: 'Annotations is an unstructured key value map stored with a resource
+      that may be set by external tools to store and retrieve arbitrary metadata.
+      They are not queryable and should be preserved when modifying objects. More
+      info: http://kubernetes.io/docs/user-guide/annotations'
+    type: object
+  clusterName:
+    description: The name of the cluster which the object belongs to. This is used
+      to distinguish resources with same name and namespace in different clusters.
+      This field is not set anywhere right now and apiserver is going to ignore it
+      if set in create or update request.
+    type: string
+  creationTimestamp:
+    type: string
+    format: date-time
+    nullable: true
+    description: |-
+      CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.
+      Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+  deletionGracePeriodSeconds:
+    description: Number of seconds allowed for this object to gracefully terminate
+      before it will be removed from the system. Only set when deletionTimestamp is
+      also set. May only be shortened. Read-only.
+    format: int64
+    type: integer
+  deletionTimestamp:
+    type: string
+    description: |-
+      DeletionTimestamp is RFC 3339 date and time at which this resource will be deleted. This field is set by the server when a graceful deletion is requested by the user, and is not directly settable by a client. The resource is expected to be deleted (no longer visible from resource lists, and not reachable by name) after the time in this field, once the finalizers list is empty. As long as the finalizers list contains items, deletion is blocked. Once the deletionTimestamp is set, this value may not be unset or be set further into the future, although it may be shortened or the resource may be deleted prior to this time. For example, a user may request that a pod is deleted in 30 seconds. The Kubelet will react by sending a graceful termination signal to the containers in the pod. After that 30 seconds, the Kubelet will send a hard termination signal (SIGKILL) to the container and after cleanup, remove the pod from the API. In the presence of network partitions, this object may still exist after this timestamp, until an administrator or automated process can determine the resource is fully terminated. If not set, graceful deletion of the object has not been requested.
+      Populated by the system when a graceful deletion is requested. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+  finalizers:
+    description: Must be empty before the object is deleted from the registry. Each
+      entry is an identifier for the responsible component that will remove the entry
+      from the list. If the deletionTimestamp of the object is non-nil, entries in
+      this list can only be removed. Finalizers may be processed and removed in any
+      order.  Order is NOT enforced because it introduces significant risk of stuck
+      finalizers. finalizers is a shared field, any actor with permission can reorder
+      it. If the finalizer list is processed in order, then this can lead to a situation
+      in which the component responsible for the first finalizer in the list is waiting
+      for a signal (field value, external system, or other) produced by a component
+      responsible for a finalizer later in the list, resulting in a deadlock. Without
+      enforced ordering finalizers are free to order amongst themselves and are not
+      vulnerable to ordering changes in the list.
+    items:
+      type: string
+    type: array
+  generateName:
+    description: |-
+      GenerateName is an optional prefix, used by the server, to generate a unique name ONLY IF the Name field has not been provided. If this field is used, the name returned to the client will be different than the name passed. This value will also be combined with a unique suffix. The provided value has the same validation rules as the Name field, and may be truncated by the length of the suffix required to make the value unique on the server.
+      If this field is specified and the generated name exists, the server will NOT return a 409 - instead, it will either return 201 Created or 500 with Reason ServerTimeout indicating a unique name could not be found in the time allotted, and the client should retry (optionally after the time indicated in the Retry-After header).
+      Applied only if Name is not specified. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#idempotency
+    type: string
+  generation:
+    description: A sequence number representing a specific generation of the desired
+      state. Populated by the system. Read-only.
+    format: int64
+    type: integer
+  labels:
+    additionalProperties:
+      type: string
+    description: 'Map of string keys and values that can be used to organize and categorize
+      (scope and select) objects. May match selectors of replication controllers and
+      services. More info: http://kubernetes.io/docs/user-guide/labels'
+    type: object
+  managedFields:
+    description: ManagedFields maps workflow-id and version to the set of fields that
+      are managed by that workflow. This is mostly for internal housekeeping, and
+      users typically shouldn't need to set or understand this field. A workflow can
+      be the user's name, a controller's name, or the name of a specific apply path
+      like "ci-cd". The set of fields is always in the version that the workflow used
+      when modifying the object.
+    items:
+      type: object
+    type: array
+  name:
+    description: 'Name must be unique within a namespace. Is required when creating
+      resources, although some resources may allow a client to request the generation
+      of an appropriate name automatically. Name is primarily intended for creation
+      idempotence and configuration definition. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+    type: string
+  namespace:
+    description: |-
+      Namespace defines the space within which each name must be unique. An empty namespace is equivalent to the "default" namespace, but "default" is the canonical representation. Not all objects are required to be scoped to a namespace - the value of this field for those objects will be empty.
+      Must be a DNS_LABEL. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/namespaces
+    type: string
+  ownerReferences:
+    description: List of objects depended by this object. If ALL objects in the list
+      have been deleted, this object will be garbage collected. If this object is
+      managed by a controller, then an entry in this list will point to this controller,
+      with the controller field set to true. There cannot be more than one managing
+      controller.
+    items:
+      type: object
+    type: array
+  resourceVersion:
+    description: |-
+      An opaque value that represents the internal version of this object that can be used by clients to determine when objects have changed. May be used for optimistic concurrency, change detection, and the watch operation on a resource or set of resources. Clients must treat these values as opaque and passed unmodified back to the server. They may only be valid for a particular resource or set of resources.
+      Populated by the system. Read-only. Value must be treated as opaque by clients and . More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+    type: string
+  selfLink:
+    description: |-
+      SelfLink is a URL representing this object. Populated by the system. Read-only.
+      DEPRECATED Kubernetes will stop propagating this field in 1.20 release and the field is planned to be removed in 1.21 release.
+    type: string
+  uid:
+    description: |-
+      UID is the unique in time and space value for this object. It is typically generated by the server on successful creation of a resource and is not allowed to change on PUT operations.
+      Populated by the system. Read-only. More info: http://kubernetes.io/docs/user-guide/identifiers#uids
+    type: string

--- a/hack/patch-crds.sh
+++ b/hack/patch-crds.sh
@@ -29,10 +29,18 @@ $YQ m -i "$ROOT_DIR/$v1beta1/datadoghq.com_extendeddaemonsets.yaml" "$ROOT_DIR/h
 $YQ m -i "$ROOT_DIR/$v1/datadoghq.com_extendeddaemonsetreplicasets.yaml" "$ROOT_DIR/hack/patch-crd-v1-protocol-kube1.18.yaml"
 $YQ m -i "$ROOT_DIR/$v1/datadoghq.com_extendeddaemonsets.yaml" "$ROOT_DIR/hack/patch-crd-v1-protocol-kube1.18.yaml"
 
+
 # Update `metadata` attribute of v1.PodTemplateSpec to properly validate the
 # resource's metadata, since the automatically generated validation is
 # insufficient.
-$YQ m -i "$ROOT_DIR/$v1beta1/datadoghq.com_extendeddaemonsetreplicasets.yaml" "$ROOT_DIR/hack/patch-crd-metadata.yaml"
-$YQ m -i "$ROOT_DIR/$v1beta1/datadoghq.com_extendeddaemonsets.yaml" "$ROOT_DIR/hack/patch-crd-metadata.yaml"
-$YQ m -i "$ROOT_DIR/$v1/datadoghq.com_extendeddaemonsetreplicasets.yaml" "$ROOT_DIR/hack/patch-crd-metadata.yaml"
-$YQ m -i "$ROOT_DIR/$v1/datadoghq.com_extendeddaemonsets.yaml" "$ROOT_DIR/hack/patch-crd-metadata.yaml"
+patch_CRD_metadata="$ROOT_DIR/hack/patch-crd-metadata.yaml"
+
+# Different object path in v1beta1 and v1. Notice that v1 assumes that there's just 1 version
+openAPIV3Schema_path_v1beta1="spec.validation.openAPIV3Schema"
+openAPIV3Schema_path="spec.versions[0].schema.openAPIV3Schema"
+metadata_subpath="properties.spec.properties.template.properties.metadata"
+
+$YQ w -i "$ROOT_DIR/$v1beta1/datadoghq.com_extendeddaemonsetreplicasets.yaml" "$openAPIV3Schema_path_v1beta1"."$metadata_subpath" -f "$patch_CRD_metadata"
+$YQ w -i "$ROOT_DIR/$v1beta1/datadoghq.com_extendeddaemonsets.yaml" "$openAPIV3Schema_path_v1beta1"."$metadata_subpath" -f "$patch_CRD_metadata"
+$YQ w -i "$ROOT_DIR/$v1/datadoghq.com_extendeddaemonsetreplicasets.yaml" "$openAPIV3Schema_path"."$metadata_subpath" -f "$patch_CRD_metadata"
+$YQ w -i "$ROOT_DIR/$v1/datadoghq.com_extendeddaemonsets.yaml" "$openAPIV3Schema_path"."$metadata_subpath" -f "$patch_CRD_metadata"


### PR DESCRIPTION
### What does this PR do?

2 of the 3 templates in `config/crd/bases/v1` fail when applying them with this error:
```
unknown field "validation" in io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinitionSpec
```

That `validation` field is added by `hack/patch-crds.sh`. It works with `v1beta1`, but not with `v1`.

This PR fixes the issue by adapting `hack/patch-crds.sh` and the file it uses (`patch-crd-metadata.yaml`) to work with `v1`.


### Describe your test plan

Run `kubectl apply -f config/crd/bases/v1/`. It should not raise any errors.
