### PR TITLE
[eds_validate test] Use correct spec in "valid autoPause no autoFail" test

### DIFF
--- a/api/v1alpha1/extendeddaemonset_validate_test.go
+++ b/api/v1alpha1/extendeddaemonset_validate_test.go
@@ -89,7 +89,7 @@ func TestValidateExtendedDaemonSetSpec(t *testing.T) {
 		},
 		{
 			name: "valid autoPause no autoFail",
-			spec: validAutoFailNoAutoPause,
+			spec: validAutoPauseNoAutoFail,
 		},
 		{
 			name: "valid manual validation mode",


### PR DESCRIPTION
### What does this PR do?

Fixes the "valid autoPause no autoFail" test in `api/v1alpha1/extendeddaemonset_validate_test.go`.

