### PR TITLE
Fix "up-to-date" value reported in EDS status

### DIFF
--- a/controllers/extendeddaemonset/controller.go
+++ b/controllers/extendeddaemonset/controller.go
@@ -225,7 +225,7 @@ func (r *Reconciler) updateInstanceWithCurrentRS(logger logr.Logger, now time.Ti
 	if current != nil {
 		newDaemonset.Status.ActiveReplicaSet = current.Name
 		newDaemonset.Status.Desired = current.Status.Desired
-		newDaemonset.Status.UpToDate = current.Status.Available
+		newDaemonset.Status.UpToDate = current.Status.Current
 		newDaemonset.Status.Available = current.Status.Available
 		newDaemonset.Status.State = nonCanaryState(daemonset.GetAnnotations())
 		newDaemonset.Status.IgnoredUnresponsiveNodes = current.Status.IgnoredUnresponsiveNodes

--- a/controllers/extendeddaemonset/controller_test.go
+++ b/controllers/extendeddaemonset/controller_test.go
@@ -585,9 +585,12 @@ func TestReconcileExtendedDaemonSet_updateInstanceWithCurrentRS(t *testing.T) {
 	replicassetCurrent := test.NewExtendedDaemonSetReplicaSet("bar", "current", &test.NewExtendedDaemonSetReplicaSetOptions{
 		Labels: map[string]string{"foo-key": "current-value"},
 		Status: &datadoghqv1alpha1.ExtendedDaemonSetReplicaSetStatus{
-			Desired:   3,
-			Available: 3,
+			// Define different values for all the attributes to avoid passing tests by chance.
+			// Constraints: desired >= current >= ready >= available
+			Desired:   4,
+			Current:   3,
 			Ready:     2,
+			Available: 1,
 		},
 	})
 
@@ -609,10 +612,10 @@ func TestReconcileExtendedDaemonSet_updateInstanceWithCurrentRS(t *testing.T) {
 		daemonsetWithStatus.ResourceVersion = "1"
 		daemonsetWithStatus.Status = datadoghqv1alpha1.ExtendedDaemonSetStatus{
 			ActiveReplicaSet: "current",
-			Desired:          3,
+			Desired:          4,
 			Current:          3,
-			Available:        3,
 			Ready:            2,
+			Available:        1,
 			UpToDate:         3,
 			State:            "Running",
 		}
@@ -648,10 +651,10 @@ func TestReconcileExtendedDaemonSet_updateInstanceWithCurrentRS(t *testing.T) {
 			},
 			Status: &datadoghqv1alpha1.ExtendedDaemonSetStatus{
 				ActiveReplicaSet: "current",
-				Desired:          3,
+				Desired:          4,
 				Current:          3,
-				Available:        3,
 				Ready:            2,
+				Available:        1,
 				UpToDate:         3,
 				Canary: &datadoghqv1alpha1.ExtendedDaemonSetStatusCanary{
 					Nodes:      []string{"node1"},


### PR DESCRIPTION
### What does this PR do?

The "up-to-date" value of the Extended DaemonSet status was set to the number of available replicas reported by the ERS. 

This PR changes it to be "current" instead. The reason is that a replica does not need to be available to be considered up-to-date. To be considered "up-to-date" is enough to have the same template spec (image, etc.).


### Additional Notes

To test this change, I had to change the number of desired, current, available, etc. set in the unit tests for the affected function. Some of those attributes had the same value which can make the test pass by chance.


### Describe your test plan

When running `kubectl get eds`, the `up-to-date` value should match the `current` value of the updated ERS shown in `kubectl get ers`.
