### PR TITLE
[CI] Use tmpl-v2 image

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -178,7 +178,7 @@ trigger_internal_eds_image:
     branch: master
     strategy: depend
   variables:
-    IMAGE_VERSION: tmpl-v1
+    IMAGE_VERSION: tmpl-v2
     IMAGE_NAME: $PROJECTNAME
     RELEASE_TAG: ${CI_COMMIT_REF_SLUG}
     BUILD_TAG: ${CI_COMMIT_REF_SLUG}
@@ -199,7 +199,7 @@ trigger_internal_eds_check_image:
     branch: master
     strategy: depend
   variables:
-    IMAGE_VERSION: tmpl-v1
+    IMAGE_VERSION: tmpl-v2
     IMAGE_NAME: $PROJECTNAME_CHECK
     RELEASE_TAG: ${CI_COMMIT_REF_SLUG}
     BUILD_TAG: ${CI_COMMIT_REF_SLUG}


### PR DESCRIPTION
### What does this PR do?

Changes `IMAGE_VERSION` to `tmpl-v2` in Gitlab CI.
We might revert this after we find out why v1 does not work.
Note that the base branch for this PR is `v0.7`.


