### PR TITLE
[controllers/eds] Fix "available" and "up to date" in `get eds`

### DIFF
--- a/controllers/extendeddaemonset/controller.go
+++ b/controllers/extendeddaemonset/controller.go
@@ -481,7 +481,7 @@ func manageStatus(status *datadoghqv1alpha1.ExtendedDaemonSetStatus, upToDate *d
 			status.Canary = &datadoghqv1alpha1.ExtendedDaemonSetStatusCanary{}
 		}
 		status.Desired += upToDate.Status.Desired
-		status.UpToDate += upToDate.Status.Available
+		status.UpToDate = upToDate.Status.Current
 		status.IgnoredUnresponsiveNodes += upToDate.Status.IgnoredUnresponsiveNodes
 
 		if !isCanaryPaused {

--- a/controllers/extendeddaemonset/controller.go
+++ b/controllers/extendeddaemonset/controller.go
@@ -121,6 +121,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	for id, rs := range replicaSetList.Items {
 		podsCounter.Ready += rs.Status.Ready
 		podsCounter.Current += rs.Status.Current
+		podsCounter.Available += rs.Status.Available
 
 		// Check if ReplicaSet is currently active
 		if rs.Name == instance.Status.ActiveReplicaSet {
@@ -222,11 +223,11 @@ func (r *Reconciler) updateInstanceWithCurrentRS(logger logr.Logger, now time.Ti
 	newDaemonset := daemonset.DeepCopy()
 	newDaemonset.Status.Current = podsCounter.Current
 	newDaemonset.Status.Ready = podsCounter.Ready
+	newDaemonset.Status.Available = podsCounter.Available
 	if current != nil {
 		newDaemonset.Status.ActiveReplicaSet = current.Name
 		newDaemonset.Status.Desired = current.Status.Desired
 		newDaemonset.Status.UpToDate = current.Status.Current
-		newDaemonset.Status.Available = current.Status.Available
 		newDaemonset.Status.State = nonCanaryState(daemonset.GetAnnotations())
 		newDaemonset.Status.IgnoredUnresponsiveNodes = current.Status.IgnoredUnresponsiveNodes
 	}
@@ -481,7 +482,6 @@ func manageStatus(status *datadoghqv1alpha1.ExtendedDaemonSetStatus, upToDate *d
 		}
 		status.Desired += upToDate.Status.Desired
 		status.UpToDate += upToDate.Status.Available
-		status.Available += upToDate.Status.Available
 		status.IgnoredUnresponsiveNodes += upToDate.Status.IgnoredUnresponsiveNodes
 
 		if !isCanaryPaused {
@@ -612,6 +612,7 @@ func clearCanaryAnnotations(eds *datadoghqv1alpha1.ExtendedDaemonSet) bool {
 }
 
 type podsCounterType struct {
-	Current int32
-	Ready   int32
+	Current   int32
+	Ready     int32
+	Available int32
 }

--- a/controllers/extendeddaemonset/controller_test.go
+++ b/controllers/extendeddaemonset/controller_test.go
@@ -624,6 +624,8 @@ func TestReconcileExtendedDaemonSet_updateInstanceWithCurrentRS(t *testing.T) {
 	intString1 := intstr.FromInt(1)
 	daemonsetWithCanaryWithStatus := daemonsetWithStatus.DeepCopy()
 	{
+		// replicassetUpToDate defined above has no replicas so UpToDate should be 0
+		daemonsetWithCanaryWithStatus.Status.UpToDate = 0
 		daemonsetWithCanaryWithStatus.Status.State = datadoghqv1alpha1.ExtendedDaemonSetStatusStateCanary
 		daemonsetWithCanaryWithStatus.Spec.Strategy.Canary = &datadoghqv1alpha1.ExtendedDaemonSetSpecStrategyCanary{
 			Replicas: &intString1,
@@ -655,7 +657,7 @@ func TestReconcileExtendedDaemonSet_updateInstanceWithCurrentRS(t *testing.T) {
 				Current:          3,
 				Ready:            2,
 				Available:        1,
-				UpToDate:         3,
+				UpToDate:         0, // replicassetUpToDate defined above has no replicas so UpToDate should be 0
 				Canary: &datadoghqv1alpha1.ExtendedDaemonSetStatusCanary{
 					Nodes:      []string{"node1"},
 					ReplicaSet: "foo-1",
@@ -713,6 +715,9 @@ func TestReconcileExtendedDaemonSet_updateInstanceWithCurrentRS(t *testing.T) {
 
 	daemonsetWithCanaryFailedWithoutAnnotationsWanted := daemonsetWithCanaryFailedOldStatus.DeepCopy()
 	{
+		// When the canary fails, the number of "Updated" replicas should equal
+		// the number of current ones.
+		daemonsetWithCanaryFailedWithoutAnnotationsWanted.Status.UpToDate = replicassetCurrent.Status.Current
 		delete(daemonsetWithCanaryFailedWithoutAnnotationsWanted.Annotations, datadoghqv1alpha1.ExtendedDaemonSetCanaryFailedAnnotationKey)
 		delete(daemonsetWithCanaryFailedWithoutAnnotationsWanted.Annotations, datadoghqv1alpha1.ExtendedDaemonSetCanaryFailedReasonAnnotationKey)
 		daemonsetWithCanaryFailedWithoutAnnotationsWanted.ResourceVersion = "3"


### PR DESCRIPTION
### What does this PR do?

Fixes the "available" and "up to date" values in the `kubectl get eds` output.

"Available" should equal the sum of "available" of the active replica and the canary. There was a case where this was not working. When the canary duration expired and it became the active replica, "available" didn't take into account the replicas of the old set that were still there.

This PR also fixes a bug in the "Up to date" values. When there's a canary, "Up to date" should equal the number of replicas in the canary, but the code was adding the current ones plus the canary.

Notice that the base branch of this PR is `v0.7`

### Describe your test plan

Set up a cluster with more than 1 worker node. You can use kind for that.

Deploy the example EDS: `kubectl apply -f examples/foo-eds_v1.yaml`.

Run `kubectl get eds --watch` and `kubectl get ers --watch`. And wait until all the desired replicas are available.

Deploy the v2 of the example `kubectl apply -f examples/foo-eds_v2.yaml` (Adjust the timeout so you don't have to wait for 5 minutes). Check these 2 things:
- While the canary has not become the active replica, check that the "up to date" value of `get eds` corresponds to the number of "current" replicas of the canary. If you have not modified the number of replicas in `examples/foo-eds_v2.yaml`, this should be 0 (at the start) and 1 later. It should go over 1 only after the canary becomes the active replica.
- When the time that you chose in the previous step (or the default of 5 min) passes, pay attention to the "available" column of `get eds`. The value should equal the number of available replicas of the canary (that now is the active) plus the number of available replicas of the old set. Both of those values are shown in `get ers`.
