### PR TITLE
fix: simplify cleanupReplicaSet for less memory allocations

### DIFF
--- a/controllers/extendeddaemonset/utils.go
+++ b/controllers/extendeddaemonset/utils.go
@@ -6,12 +6,7 @@
 package extendeddaemonset
 
 import (
-	"context"
 	"time"
-
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/labels"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	datadoghqv1alpha1 "github.com/DataDog/extendeddaemonset/api/v1alpha1"
 	"github.com/DataDog/extendeddaemonset/controllers/extendeddaemonsetreplicaset/conditions"
@@ -121,17 +116,4 @@ func IsCanaryDeploymentFailed(dsAnnotations map[string]string, ers *datadoghqv1a
 	}
 
 	return false
-}
-
-func getPodListFromReplicaSet(c client.Client, ds *datadoghqv1alpha1.ExtendedDaemonSetReplicaSet) (*corev1.PodList, error) {
-	podList := &corev1.PodList{}
-	podSelector := labels.Set{datadoghqv1alpha1.ExtendedDaemonSetReplicaSetNameLabelKey: ds.Name}
-	podListOptions := []client.ListOption{
-		&client.MatchingLabelsSelector{Selector: podSelector.AsSelectorPreValidated()},
-	}
-	if err := c.List(context.TODO(), podList, podListOptions...); err != nil {
-		return nil, err
-	}
-
-	return podList, nil
 }


### PR DESCRIPTION
### What does this PR do?

Simplify `cleanupReplicaSet`: instead of getting full pod list to decide whether a ERS must be deleted, rely on the info stored in its status.

Querying the a pod list is a costly operation especially in larger clusters during a rolling update as the old ERS still have a large non-nil list of pods attached to it.

### Motivation

![image](https://user-images.githubusercontent.com/38987709/142845264-3101abc2-40d8-4081-8acb-c1f84e1641cc.png)

A is before the rolling update, B is during the rolling update (cluster size: 1.6k nodes)

### Additional Notes

`cleanupReplicaSet` is covered by unit tests/

### Describe your test plan

Rollout new workload versions multiple times, make sure old ERSs get deleted.
