### PR TITLE
fix: avoid empty reason when auto-pausing canary

### DIFF
--- a/api/v1alpha1/extendeddaemonset_types.go
+++ b/api/v1alpha1/extendeddaemonset_types.go
@@ -151,6 +151,14 @@ const (
 	ExtendedDaemonSetStatusReasonErrImagePull ExtendedDaemonSetStatusReason = "ErrImagePull"
 	// ExtendedDaemonSetStatusReasonImagePullBackOff represent ImagePullBackOff as the reason for the ExtendedDaemonSet status state.
 	ExtendedDaemonSetStatusReasonImagePullBackOff ExtendedDaemonSetStatusReason = "ImagePullBackOff"
+	// ExtendedDaemonSetStatusReasonImageInspectError represent ImageInspectError as the reason for the ExtendedDaemonSet status state.
+	ExtendedDaemonSetStatusReasonImageInspectError ExtendedDaemonSetStatusReason = "ImageInspectError"
+	// ExtendedDaemonSetStatusReasonErrImageNeverPull represent ErrImageNeverPull as the reason for the ExtendedDaemonSet status state.
+	ExtendedDaemonSetStatusReasonErrImageNeverPull ExtendedDaemonSetStatusReason = "ErrImageNeverPull"
+	// ExtendedDaemonSetStatusReasonRegistryUnavailable represent RegistryUnavailable as the reason for the ExtendedDaemonSet status state.
+	ExtendedDaemonSetStatusReasonRegistryUnavailable ExtendedDaemonSetStatusReason = "RegistryUnavailable"
+	// ExtendedDaemonSetStatusReasonInvalidImageName represent InvalidImageName as the reason for the ExtendedDaemonSet status state.
+	ExtendedDaemonSetStatusReasonInvalidImageName ExtendedDaemonSetStatusReason = "InvalidImageName"
 	// ExtendedDaemonSetStatusReasonCreateContainerConfigError represent CreateContainerConfigError as the reason for the ExtendedDaemonSet status state.
 	ExtendedDaemonSetStatusReasonCreateContainerConfigError ExtendedDaemonSetStatusReason = "CreateContainerConfigError"
 	// ExtendedDaemonSetStatusReasonCreateContainerError represent CreateContainerError as the reason for the ExtendedDaemonSet status state.
@@ -159,6 +167,8 @@ const (
 	ExtendedDaemonSetStatusReasonPreStartHookError ExtendedDaemonSetStatusReason = "PreStartHookError"
 	// ExtendedDaemonSetStatusReasonPostStartHookError represent PostStartHookError as the reason for the ExtendedDaemonSet status state.
 	ExtendedDaemonSetStatusReasonPostStartHookError ExtendedDaemonSetStatusReason = "PostStartHookError"
+	// ExtendedDaemonSetStatusReasonPreCreateHookError represent PreCreateHookError as the reason for the ExtendedDaemonSet status state.
+	ExtendedDaemonSetStatusReasonPreCreateHookError ExtendedDaemonSetStatusReason = "PreCreateHookError"
 	// ExtendedDaemonSetStatusReasonStartError represent StartError as the reason for the ExtendedDaemonSet status state.
 	ExtendedDaemonSetStatusReasonStartError ExtendedDaemonSetStatusReason = "StartError"
 	// ExtendedDaemonSetStatusReasonUnknown represents an Unknown reason for the status state.

--- a/pkg/controller/utils/pod/pod_test.go
+++ b/pkg/controller/utils/pod/pod_test.go
@@ -217,7 +217,7 @@ func TestIsPodReady(t *testing.T) {
 }
 
 func TestIsCannotStartReason(t *testing.T) {
-	for _, reason := range cannotStartReasons {
+	for reason := range cannotStartReasons {
 		cannotStart := IsCannotStartReason(reason)
 		assert.True(t, cannotStart)
 	}
@@ -479,6 +479,24 @@ func Test_HighestRestartCount(t *testing.T) {
 			wantRestartCount: 10,
 			wantReason:       datadoghqv1alpha1.ExtendedDaemonSetStatusReasonCLB,
 		},
+		{
+			name: "restarts with empty reason",
+			pod: ctrltest.NewPod("bar", "pod1", "node1", &ctrltest.NewPodOptions{
+				ContainerStatuses: []v1.ContainerStatus{
+					{
+						RestartCount: 10,
+						LastTerminationState: v1.ContainerState{
+							Terminated: &v1.ContainerStateTerminated{
+								Reason: "",
+							},
+						},
+					},
+				},
+			},
+			),
+			wantRestartCount: 10,
+			wantReason:       datadoghqv1alpha1.ExtendedDaemonSetStatusReasonUnknown,
+		},
 	}
 
 	for _, tt := range tests {
@@ -537,6 +555,25 @@ func Test_MostRecentRestart(t *testing.T) {
 			),
 			wantTime:   time.Time{},
 			wantReason: "",
+		},
+		{
+			name: "restarts with empty reason",
+			pod: ctrltest.NewPod("bar", "pod1", "node1", &ctrltest.NewPodOptions{
+				ContainerStatuses: []v1.ContainerStatus{
+					{
+						RestartCount: 10,
+						LastTerminationState: v1.ContainerState{
+							Terminated: &v1.ContainerStateTerminated{
+								Reason:     "",
+								FinishedAt: metav1.NewTime(now.Add(-time.Hour)),
+							},
+						},
+					},
+				},
+			},
+			),
+			wantTime:   now.Add(-time.Hour),
+			wantReason: datadoghqv1alpha1.ExtendedDaemonSetStatusReasonUnknown,
 		},
 	}
 


### PR DESCRIPTION
### What does this PR do?

- Make sure we don't return empty reasons in `HighestRestartCount` and `MostRecentRestart`
- Add new errors to the `cannotStartReasons` set:
  - ImageInspectError
  - ErrImageNeverPull
  - RegistryUnavailable
  - InvalidImageName
  - PreCreateHookError

### Motivation

Make the canary auto-pause more reliable

### Describe your test plan

`InvalidImageName` is the easiest option to reproduce:
- Deploy a valid eds with canary auto-pause enabled.
- Update the workload image name to an invalid value (include non alpha-numerical characters).
- Make sure the new canary is paused with the correct reason printed
```
  NAMESPACE  NAME              DESIRED  CURRENT  READY  UP-TO-DATE  AVAILABLE  IGNORED UNRESPONSIVE NODES  STATUS         REASON            ACTIVE RS               CANARY RS               AGE
  default    pause-containers  4        4        2      2           2          0                           Canary Paused  InvalidImageName  pause-containers-sz5ft  pause-containers-2qdx6  16 minutes
```