### PR TITLE
[plugin] add age to canary pods cmd

### DIFF
--- a/pkg/plugin/common/pods.go
+++ b/pkg/plugin/common/pods.go
@@ -77,7 +77,7 @@ func printPods(c client.Client, selector labels.Selector, out io.Writer, notRead
 			continue
 		}
 		ready, containers, restarts := containersInfo(&pod)
-		table.Append([]string{pod.Name, ready, string(pod.Status.Phase), reason, containers, restarts, pod.Spec.NodeName, getNodeReadiness(c, pod.Spec.NodeName)})
+		table.Append([]string{pod.Name, ready, string(pod.Status.Phase), reason, containers, restarts, pod.Spec.NodeName, getNodeReadiness(c, pod.Spec.NodeName), GetDuration(&pod.ObjectMeta)})
 	}
 
 	table.Render()

--- a/pkg/plugin/common/table.go
+++ b/pkg/plugin/common/table.go
@@ -14,7 +14,7 @@ import (
 // newPodsTable returns a table to print pods.
 func newPodsTable(out io.Writer) *tablewriter.Table {
 	table := tablewriter.NewWriter(out)
-	table.SetHeader([]string{"Pod", "Ready", "Phase", "Reason", "Not ready containers", "Restarts", "Node", "Node Ready"})
+	table.SetHeader([]string{"Pod", "Ready", "Phase", "Reason", "Not ready containers", "Restarts", "Node", "Node Ready", "Age"})
 	table.SetBorders(tablewriter.Border{Left: false, Top: false, Right: false, Bottom: false})
 	table.SetHeaderAlignment(tablewriter.ALIGN_LEFT)
 	table.SetRowLine(false)

--- a/pkg/plugin/common/utils.go
+++ b/pkg/plugin/common/utils.go
@@ -10,14 +10,22 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"time"
 
+	"github.com/hako/durafmt"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // IntToString converts int32 into string.
 func IntToString(i int32) string {
 	return fmt.Sprintf("%d", i)
+}
+
+// GetDuration gets uptime duration of a resource.
+func GetDuration(obj *metav1.ObjectMeta) string {
+	return durafmt.ParseShort(time.Since(obj.CreationTimestamp.Time)).String()
 }
 
 // isPodNotReady returns whether the pod is ready, returns the the reason if not ready.

--- a/pkg/plugin/get/common.go
+++ b/pkg/plugin/get/common.go
@@ -5,14 +5,7 @@
 
 package get
 
-import (
-	"time"
-
-	"github.com/hako/durafmt"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	"github.com/DataDog/extendeddaemonset/api/v1alpha1"
-)
+import "github.com/DataDog/extendeddaemonset/api/v1alpha1"
 
 func getCanaryRS(eds *v1alpha1.ExtendedDaemonSet) string {
 	if eds.Status.Canary != nil {
@@ -20,8 +13,4 @@ func getCanaryRS(eds *v1alpha1.ExtendedDaemonSet) string {
 	}
 
 	return "-"
-}
-
-func getDuration(obj *metav1.ObjectMeta) string {
-	return durafmt.ParseShort(time.Since(obj.CreationTimestamp.Time)).String()
 }

--- a/pkg/plugin/get/get.go
+++ b/pkg/plugin/get/get.go
@@ -138,7 +138,7 @@ func (o *getOptions) run() error {
 
 	table := newGetTable(o.Out)
 	for _, item := range edsList.Items {
-		data := []string{item.Namespace, item.Name, common.IntToString(item.Status.Desired), common.IntToString(item.Status.Current), common.IntToString(item.Status.Ready), common.IntToString(item.Status.UpToDate), common.IntToString(item.Status.Available), common.IntToString(item.Status.IgnoredUnresponsiveNodes), string(item.Status.State), string(item.Status.Reason), item.Status.ActiveReplicaSet, getCanaryRS(&item), getDuration(&item.ObjectMeta)}
+		data := []string{item.Namespace, item.Name, common.IntToString(item.Status.Desired), common.IntToString(item.Status.Current), common.IntToString(item.Status.Ready), common.IntToString(item.Status.UpToDate), common.IntToString(item.Status.Available), common.IntToString(item.Status.IgnoredUnresponsiveNodes), string(item.Status.State), string(item.Status.Reason), item.Status.ActiveReplicaSet, getCanaryRS(&item), common.GetDuration(&item.ObjectMeta)}
 		table.Append(data)
 	}
 

--- a/pkg/plugin/get/geters.go
+++ b/pkg/plugin/get/geters.go
@@ -138,7 +138,7 @@ func (o *getERSOptions) run() error {
 
 	table := newGetERSTable(o.Out)
 	for _, item := range ersList.Items {
-		data := []string{item.Namespace, item.Name, common.IntToString(item.Status.Desired), common.IntToString(item.Status.Current), common.IntToString(item.Status.Ready), common.IntToString(item.Status.Available), common.IntToString(item.Status.IgnoredUnresponsiveNodes), item.Status.Status, getDuration(&item.ObjectMeta)}
+		data := []string{item.Namespace, item.Name, common.IntToString(item.Status.Desired), common.IntToString(item.Status.Current), common.IntToString(item.Status.Ready), common.IntToString(item.Status.Available), common.IntToString(item.Status.IgnoredUnresponsiveNodes), item.Status.Status, common.GetDuration(&item.ObjectMeta)}
 		table.Append(data)
 	}
 


### PR DESCRIPTION
### What does this PR do?

Move `getDuration` function to common/utils.go
Add `Age` column to `canary pods` cmd

### Motivation

To be able to easily see uptime of canary pods

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Build the binary with `make kubectl-eds`
Deploy a daemonset with a canary
Run `kubectl eds canary pods <ds name>` and make sure the `Age` makes sense