### PR TITLE
fix: enable profiling after logging setup

### DIFF
--- a/main.go
+++ b/main.go
@@ -76,6 +76,14 @@ func main() {
 	exitCode := 0
 	defer func() { os.Exit(exitCode) }()
 
+	// Logging setup
+	if err := customSetupLogging(*logLevel, logEncoder); err != nil {
+		setupLog.Error(err, "unable to setup the logger")
+		exitCode = 1
+
+		return
+	}
+
 	if ddProfilingEnabled {
 		setupLog.Info("Starting datadog profiler")
 		if err := profiler.Start(
@@ -86,14 +94,6 @@ func main() {
 		}
 
 		defer profiler.Stop()
-	}
-
-	// Logging setup
-	if err := customSetupLogging(*logLevel, logEncoder); err != nil {
-		setupLog.Error(err, "unable to setup the logger")
-		exitCode = 1
-
-		return
 	}
 
 	// Print version information


### PR DESCRIPTION
### What does this PR do?

Configure the logger before calling `setupLog`. 

### Motivation

This branch was logging before the logger was setup

```golang
	if ddProfilingEnabled {
		setupLog.Info("Starting datadog profiler")
...
	}
```

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Make sure this line `Starting datadog profiler` is logged correctly when profiling is enabled
