### PR TITLE
fix: don't overwrite canary auto-pause reason

### DIFF
--- a/controllers/extendeddaemonsetreplicaset/strategy/canary.go
+++ b/controllers/extendeddaemonsetreplicaset/strategy/canary.go
@@ -49,7 +49,7 @@ func manageCanaryStatus(annotations map[string]string, params *Parameters, now t
 	result.NewStatus.Status = string(ReplicaSetStatusCanary)
 
 	result.IsFailed = eds.IsCanaryDeploymentFailed(annotations, params.Replicaset)
-	result.IsPaused, _ = eds.IsCanaryDeploymentPaused(annotations, params.Replicaset)
+	result.IsPaused, result.PausedReason = eds.IsCanaryDeploymentPaused(annotations, params.Replicaset)
 	result.IsUnpaused = eds.IsCanaryDeploymentUnpaused(annotations)
 
 	var (

--- a/controllers/extendeddaemonsetreplicaset/strategy/canary_test.go
+++ b/controllers/extendeddaemonsetreplicaset/strategy/canary_test.go
@@ -402,6 +402,75 @@ func TestManageCanaryStatus_HighRestartsLeadingToPause(t *testing.T) {
 	test.Run(t)
 }
 
+func TestManageCanaryStatus_CanaryPausedAlready(t *testing.T) {
+	now := time.Now()
+	test := canaryStatusTest{
+		now: now,
+		params: &Parameters{
+			EDSName: "foo",
+			Strategy: &v1alpha1.ExtendedDaemonSetSpecStrategy{
+				Canary: &v1alpha1.ExtendedDaemonSetSpecStrategyCanary{
+					AutoPause: &v1alpha1.ExtendedDaemonSetSpecStrategyCanaryAutoPause{
+						Enabled:     v1alpha1.NewBool(true),
+						MaxRestarts: v1alpha1.NewInt32(2),
+					},
+					AutoFail: &v1alpha1.ExtendedDaemonSetSpecStrategyCanaryAutoFail{
+						Enabled:     v1alpha1.NewBool(false),
+						MaxRestarts: v1alpha1.NewInt32(5),
+					},
+				},
+			},
+			Replicaset: &v1alpha1.ExtendedDaemonSetReplicaSet{
+				Spec: v1alpha1.ExtendedDaemonSetReplicaSetSpec{
+					TemplateGeneration: "v1",
+				},
+				Status: v1alpha1.ExtendedDaemonSetReplicaSetStatus{
+					Conditions: []v1alpha1.ExtendedDaemonSetReplicaSetCondition{
+						{
+							Type:               v1alpha1.ConditionTypeCanaryPaused,
+							Status:             v1.ConditionTrue,
+							LastTransitionTime: metav1.NewTime(now),
+							LastUpdateTime:     metav1.NewTime(now),
+							Reason:             "CrashLoopBackOff",
+						},
+					},
+				},
+			},
+			NewStatus:   &v1alpha1.ExtendedDaemonSetReplicaSetStatus{},
+			CanaryNodes: testCanaryNodeNames,
+			NodeByName:  testCanaryNodes,
+			PodByNodeName: map[*NodeItem]*v1.Pod{
+				testCanaryNodes["a"]: nil,
+				testCanaryNodes["b"]: nil,
+				testCanaryNodes["c"]: nil,
+			},
+			Logger: testLogger,
+		},
+		result: &Result{
+			NewStatus: &v1alpha1.ExtendedDaemonSetReplicaSetStatus{
+				Status:    "canary",
+				Desired:   3,
+				Current:   0,
+				Ready:     0,
+				Available: 0,
+				Conditions: []v1alpha1.ExtendedDaemonSetReplicaSetCondition{
+					{
+						Type:               v1alpha1.ConditionTypeCanaryPaused,
+						Status:             v1.ConditionTrue,
+						LastTransitionTime: metav1.NewTime(now),
+						LastUpdateTime:     metav1.NewTime(now),
+						Reason:             "CrashLoopBackOff",
+					},
+				},
+			},
+			IsPaused:     true,
+			PausedReason: v1alpha1.ExtendedDaemonSetStatusReasonCLB,
+			Result:       reconcile.Result{},
+		},
+	}
+	test.Run(t)
+}
+
 func TestManageCanaryStatus_HighRestartsLeadingToFail(t *testing.T) {
 	now := time.Now()
 	restartedAt := now.Add(-time.Minute)


### PR DESCRIPTION
### What does this PR do?

Fix a bug that caused overwriting the canary auto-pause reason after reconciliation.

### Motivation

Bug fix.

### Describe your test plan

`k eds get` should print the paused reason after  auto-pausing a canary.
(Note: The bug has a racy behaviour and not always reproducible)
