### PR TITLE
move failed metric from EDS to ERS

### DIFF
--- a/controllers/extendeddaemonset/controller.go
+++ b/controllers/extendeddaemonset/controller.go
@@ -574,10 +574,10 @@ func shouldDeleteERS(now time.Time, ers *datadoghqv1alpha1.ExtendedDaemonSetRepl
 		return true
 	}
 
-	// If canary deploy has failed, delay ERS deletion for 5m so that failed metric reports
+	// If canary deploy has failed, delay ERS deletion for 2m so that failed metric reports
 	if ersconditions.IsConditionTrue(&ers.Status, datadoghqv1alpha1.ConditionTypeCanaryFailed) {
 		failedIdx := ersconditions.GetIndexForConditionType(&ers.Status, datadoghqv1alpha1.ConditionTypeCanaryFailed)
-		t := ers.Status.Conditions[failedIdx].LastTransitionTime.Add(time.Minute * 5)
+		t := ers.Status.Conditions[failedIdx].LastTransitionTime.Add(time.Minute * 2)
 		if now.Before(t) {
 			return false
 		}

--- a/controllers/extendeddaemonset/controller_test.go
+++ b/controllers/extendeddaemonset/controller_test.go
@@ -426,6 +426,7 @@ func Test_selectCurrentReplicaSet(t *testing.T) {
 }
 
 func TestReconciler_cleanupReplicaSet(t *testing.T) {
+	now := time.Now()
 	eventBroadcaster := record.NewBroadcaster()
 	eventBroadcaster.StartLogging(t.Logf)
 
@@ -498,7 +499,7 @@ func TestReconciler_cleanupReplicaSet(t *testing.T) {
 				log:      testLogger,
 				recorder: eventBroadcaster.NewRecorder(scheme.Scheme, corev1.EventSource{Component: tt.name}),
 			}
-			if err := r.cleanupReplicaSet(reqLogger, tt.args.rsList, tt.args.current, tt.args.updatetodate); (err != nil) != tt.wantErr {
+			if err := r.cleanupReplicaSet(reqLogger, now, tt.args.rsList, tt.args.current, tt.args.updatetodate); (err != nil) != tt.wantErr {
 				t.Errorf("Reconciler.cleanupReplicaSet() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})

--- a/controllers/extendeddaemonset/metrics.go
+++ b/controllers/extendeddaemonset/metrics.go
@@ -26,7 +26,6 @@ const (
 	extendeddaemonsetStatusCanaryActivated          = "eds_status_canary_activated"
 	extendeddaemonsetStatusCanaryNumberOfNodes      = "eds_status_canary_node_number"
 	extendeddaemonsetStatusCanaryPaused             = "eds_status_canary_paused"
-	extendeddaemonsetStatusCanaryFailed             = "eds_status_canary_failed"
 	extendeddaemonsetStatusRollingUpdatePaused      = "eds_status_rolling_update_paused"
 	extendeddaemonsetStatusRolloutFrozen            = "eds_status_rollout_frozen"
 	extendeddaemonsetLabels                         = "eds_labels"
@@ -244,30 +243,6 @@ func generateMetricFamilies() []ksmetric.FamilyGenerator {
 						labelKeys = append(labelKeys, "paused_reason")
 						labelValues = append(labelValues, cond.Reason)
 					}
-				}
-
-				return &ksmetric.Family{
-					Metrics: []*ksmetric.Metric{
-						{
-							Value:       val,
-							LabelKeys:   labelKeys,
-							LabelValues: labelValues,
-						},
-					},
-				}
-			},
-		},
-		{
-			Name: extendeddaemonsetStatusCanaryFailed,
-			Type: ksmetric.Gauge,
-			Help: "The failed state of the canary deployment, set to 1 if failed, else 0",
-			GenerateFunc: func(obj interface{}) *ksmetric.Family {
-				eds := obj.(*datadoghqv1alpha1.ExtendedDaemonSet)
-				labelKeys, labelValues := utils.GetLabelsValues(&eds.ObjectMeta)
-				val := float64(0)
-
-				if conditions.IsConditionTrue(&eds.Status, datadoghqv1alpha1.ConditionTypeEDSCanaryFailed) {
-					val = 1
 				}
 
 				return &ksmetric.Family{

--- a/controllers/extendeddaemonsetreplicaset/conditions/update.go
+++ b/controllers/extendeddaemonsetreplicaset/conditions/update.go
@@ -27,7 +27,7 @@ func NewExtendedDaemonSetReplicaSetCondition(conditionType datadoghqv1alpha1.Ext
 
 // UpdateExtendedDaemonSetReplicaSetStatusCondition used to update a specific ExtendedDaemonSetReplicaSetConditionType.
 func UpdateExtendedDaemonSetReplicaSetStatusCondition(status *datadoghqv1alpha1.ExtendedDaemonSetReplicaSetStatus, now metav1.Time, t datadoghqv1alpha1.ExtendedDaemonSetReplicaSetConditionType, conditionStatus corev1.ConditionStatus, reason, desc string, writeFalseIfNotExist, supportLastUpdate bool) {
-	idCondition := getIndexForConditionType(status, t)
+	idCondition := GetIndexForConditionType(status, t)
 	if idCondition >= 0 {
 		if status.Conditions[idCondition].Status != conditionStatus {
 			status.Conditions[idCondition].LastTransitionTime = now
@@ -56,7 +56,8 @@ func UpdateErrorCondition(status *datadoghqv1alpha1.ExtendedDaemonSetReplicaSetS
 	}
 }
 
-func getIndexForConditionType(status *datadoghqv1alpha1.ExtendedDaemonSetReplicaSetStatus, t datadoghqv1alpha1.ExtendedDaemonSetReplicaSetConditionType) int {
+// GetIndexForConditionType is used to get the index of a specific condition type.
+func GetIndexForConditionType(status *datadoghqv1alpha1.ExtendedDaemonSetReplicaSetStatus, t datadoghqv1alpha1.ExtendedDaemonSetReplicaSetConditionType) int {
 	if status == nil {
 		return -1
 	}
@@ -72,7 +73,7 @@ func getIndexForConditionType(status *datadoghqv1alpha1.ExtendedDaemonSetReplica
 // GetExtendedDaemonSetReplicaSetStatusCondition return the condition struct corresponding to the ExtendedDaemonSetReplicaSetConditionType provided in argument.
 // return nil if not found.
 func GetExtendedDaemonSetReplicaSetStatusCondition(status *datadoghqv1alpha1.ExtendedDaemonSetReplicaSetStatus, t datadoghqv1alpha1.ExtendedDaemonSetReplicaSetConditionType) *datadoghqv1alpha1.ExtendedDaemonSetReplicaSetCondition {
-	idCondition := getIndexForConditionType(status, t)
+	idCondition := GetIndexForConditionType(status, t)
 	if idCondition == -1 {
 		return nil
 	}


### PR DESCRIPTION
### What does this PR do?

The `canary_failed` metric was either not reporting, or reporting very sparsely (i.e. a single point).

This is because the metric depends on the EDS status to report, but upon canary failure the canary is cleared right away and the EDS status is updated accordingly.

Since the canary failure is inherently tied to the ERS, and the controller logic makes it tricky to keep the metric based on the EDS status, this PR changes this metric to report from the ERS instead. If the ERS needs to be removed because of a canary failure, there is a delay of 5m to give the metric that amount of time to report.

### Motivation

Improve telemetry so that canary failures can easily be monitored 

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Force a canary failure (made easier with subsequent PR #139)
After failure, but within 5m, check the ERS is still present: `k get ers`
Exec onto the EDS controller pod, and check that the failed metric is reporting

```
$ k exec -it eds-controller-manager-xxx -- bash
$ curl http://localhost:8080/ksmetrics | grep fail
# HELP ers_status_canary_failed The failed state of the canary deployment, set to 1 if failed, else 0
# TYPE ers_status_canary_failed gauge
ers_status_canary_failed{namespace="default",name="foo-4prqt"} 0
ers_status_canary_failed{namespace="default",name="foo-4nqsj"} 1
```
