### PR TITLE
fix: avoid to flag an ERS as stuck if rollout is done

### DIFF
--- a/controllers/extendeddaemonsetreplicaset/strategy/rollingupdate.go
+++ b/controllers/extendeddaemonsetreplicaset/strategy/rollingupdate.go
@@ -135,7 +135,7 @@ func ManageDeployment(client runtimeclient.Client, daemonset *datadoghqv1alpha1.
 		MaxUnschedulablePod: maxPodSchedulerFailure,
 	}
 	nbPodToCreate, nbPodToDelete := limits.CalculatePodToCreateAndDelete(limitParams)
-	metrics.SetRollingUpdateStuckMetric(params.Replicaset.GetName(), params.Replicaset.GetNamespace(), nbPodToDelete == 0)
+	metrics.SetRollingUpdateStuckMetric(params.Replicaset.GetName(), params.Replicaset.GetNamespace(), nbPodToDelete == 0 && len(allPodToDelete) > 0)
 	nbPodToDeleteWithConstraint := utils.MinInt(nbPodToDelete, len(allPodToDelete))
 	nbPodToCreateWithConstraint := utils.MinInt(nbPodToCreate, len(allPodToCreate))
 	params.Logger.V(1).Info(


### PR DESCRIPTION
### What does this PR do?

Set only to `true` `SetRollingUpdateStuckMetric` when we are unable to delete pods but we still have some pods to delete

### Motivation

`ers_rolling_update_stuck` can run `1` even if the rolling update is done. because it only check if we can delete pods. 
But in some case, for example a cluster scale up. we can reach the point that we have more unavailable pods than expected.


### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details you may have to test your PR.
