### PR TITLE
change fail cmd to update ers instead of eds

### DIFF
--- a/api/v1alpha1/const.go
+++ b/api/v1alpha1/const.go
@@ -24,10 +24,6 @@ const (
 	ExtendedDaemonSetCanaryPausedReasonAnnotationKey = "extendeddaemonset.datadoghq.com/canary-paused-reason"
 	// ExtendedDaemonSetCanaryUnpausedAnnotationKey annotation key used on ExtendedDaemonset in order to detect if a canary deployment is manually unpaused.
 	ExtendedDaemonSetCanaryUnpausedAnnotationKey = "extendeddaemonset.datadoghq.com/canary-unpaused"
-	// ExtendedDaemonSetCanaryFailedAnnotationKey annotation key used on ExtendedDaemonset in order to detect if a canary deployment has failed.
-	ExtendedDaemonSetCanaryFailedAnnotationKey = "extendeddaemonset.datadoghq.com/canary-failed"
-	// ExtendedDaemonSetCanaryFailedReasonAnnotationKey annotation key used on ExtendedDaemonset in order to provide a reason that the a canary deployment is failed.
-	ExtendedDaemonSetCanaryFailedReasonAnnotationKey = "extendeddaemonset.datadoghq.com/canary-failed-reason"
 	// ExtendedDaemonSetOldDaemonsetAnnotationKey annotation key used on ExtendedDaemonset in order to inform the controller that old Daemonset's pod.
 	// should be taken into consideration during the initial rolling-update.
 	ExtendedDaemonSetOldDaemonsetAnnotationKey = "extendeddaemonset.datadoghq.com/old-daemonset"

--- a/controllers/extendeddaemonset/controller.go
+++ b/controllers/extendeddaemonset/controller.go
@@ -238,7 +238,7 @@ func (r *Reconciler) updateInstanceWithCurrentRS(logger logr.Logger, now time.Ti
 	if daemonset.Spec.Strategy.Canary != nil {
 		metaNow := metav1.NewTime(now)
 		isCanaryPaused, pausedReason := IsCanaryDeploymentPaused(daemonset.GetAnnotations(), upToDate)
-		isCanaryFailed := IsCanaryDeploymentFailed(daemonset.GetAnnotations(), upToDate)
+		isCanaryFailed := IsCanaryDeploymentFailed(upToDate)
 		isCanaryActive := isCanaryActive(daemonset, current.GetName(), upToDate.GetName(), isCanaryFailed)
 		logger.V(1).Info("canary state", "isCanaryActive", isCanaryActive, "isCanaryFailed", isCanaryFailed, "isCanaryPaused", isCanaryPaused, "pausedReason", pausedReason)
 
@@ -538,7 +538,7 @@ func newReplicaSetFromInstance(daemonset *datadoghqv1alpha1.ExtendedDaemonSet) (
 	return rs, err
 }
 
-func (r *Reconciler) cleanupReplicaSet(logger logr.Logger, now time.Time, rsList *datadoghqv1alpha1.ExtendedDaemonSetReplicaSetList, current, updatetodate *datadoghqv1alpha1.ExtendedDaemonSetReplicaSet) error {
+func (r *Reconciler) cleanupReplicaSet(logger logr.Logger, now time.Time, rsList *datadoghqv1alpha1.ExtendedDaemonSetReplicaSetList, current, upToDate *datadoghqv1alpha1.ExtendedDaemonSetReplicaSet) error {
 	var errs []error
 	for id, rs := range rsList.Items {
 		if current == nil {
@@ -547,7 +547,7 @@ func (r *Reconciler) cleanupReplicaSet(logger logr.Logger, now time.Time, rsList
 		if rs.Name == current.Name {
 			continue
 		}
-		if updatetodate != nil && rs.Name == updatetodate.Name {
+		if upToDate != nil && rs.Name == upToDate.Name {
 			continue
 		}
 		if rs.DeletionTimestamp != nil {
@@ -591,8 +591,6 @@ func clearCanaryAnnotations(eds *datadoghqv1alpha1.ExtendedDaemonSet) bool {
 		datadoghqv1alpha1.ExtendedDaemonSetCanaryPausedAnnotationKey,
 		datadoghqv1alpha1.ExtendedDaemonSetCanaryPausedReasonAnnotationKey,
 		datadoghqv1alpha1.ExtendedDaemonSetCanaryUnpausedAnnotationKey,
-		datadoghqv1alpha1.ExtendedDaemonSetCanaryFailedAnnotationKey,
-		datadoghqv1alpha1.ExtendedDaemonSetCanaryFailedReasonAnnotationKey,
 	}
 	var updated bool
 	for _, key := range keysToDelete {

--- a/controllers/extendeddaemonset/controller_test.go
+++ b/controllers/extendeddaemonset/controller_test.go
@@ -710,17 +710,11 @@ func TestReconcileExtendedDaemonSet_updateInstanceWithCurrentRS(t *testing.T) {
 		}
 	}
 	daemonsetWithCanaryFailedOldStatus := daemonsetWithCanaryFailedOldWithoutAnnotationsStatus.DeepCopy()
-	{
-		daemonsetWithCanaryFailedOldStatus.Annotations[datadoghqv1alpha1.ExtendedDaemonSetCanaryFailedAnnotationKey] = "true"
-	}
-
 	daemonsetWithCanaryFailedWithoutAnnotationsWanted := daemonsetWithCanaryFailedOldStatus.DeepCopy()
 	{
 		// When the canary fails, the number of "Updated" replicas should equal
 		// the number of current ones.
 		daemonsetWithCanaryFailedWithoutAnnotationsWanted.Status.UpToDate = replicassetCurrent.Status.Current
-		delete(daemonsetWithCanaryFailedWithoutAnnotationsWanted.Annotations, datadoghqv1alpha1.ExtendedDaemonSetCanaryFailedAnnotationKey)
-		delete(daemonsetWithCanaryFailedWithoutAnnotationsWanted.Annotations, datadoghqv1alpha1.ExtendedDaemonSetCanaryFailedReasonAnnotationKey)
 		daemonsetWithCanaryFailedWithoutAnnotationsWanted.ResourceVersion = "3"
 		daemonsetWithCanaryFailedWithoutAnnotationsWanted.Status.Canary = nil
 		daemonsetWithCanaryFailedWithoutAnnotationsWanted.Status.State = datadoghqv1alpha1.ExtendedDaemonSetStatusStateCanaryFailed
@@ -882,28 +876,6 @@ func TestReconcileExtendedDaemonSet_updateInstanceWithCurrentRS(t *testing.T) {
 				},
 			},
 			want:       daemonsetWithCanaryPausedWithoutAnnotationsWanted,
-			wantResult: reconcile.Result{Requeue: false},
-			wantErr:    false,
-		},
-		{
-			now:  now,
-			name: "canary failed => update",
-			fields: fields{
-				client: fake.NewClientBuilder().WithObjects(daemonsetWithCanaryFailedOldStatus, replicassetCurrent, replicassetUpToDate).Build(),
-				scheme: s,
-			},
-			args: args{
-				logger:    log,
-				daemonset: daemonsetWithCanaryFailedOldStatus,
-				current:   replicassetCurrent,
-				upToDate:  replicassetUpToDate,
-				podsCounter: podsCounterType{
-					Current:   3,
-					Ready:     2,
-					Available: 1,
-				},
-			},
-			want:       daemonsetWithCanaryFailedWithoutAnnotationsWanted,
 			wantResult: reconcile.Result{Requeue: false},
 			wantErr:    false,
 		},

--- a/controllers/extendeddaemonset/utils.go
+++ b/controllers/extendeddaemonset/utils.go
@@ -104,15 +104,10 @@ func IsCanaryDeploymentValid(dsAnnotations map[string]string, rsName string) boo
 }
 
 // IsCanaryDeploymentFailed checks if the Canary deployment has been failed.
-func IsCanaryDeploymentFailed(dsAnnotations map[string]string, ers *datadoghqv1alpha1.ExtendedDaemonSetReplicaSet) bool {
+func IsCanaryDeploymentFailed(ers *datadoghqv1alpha1.ExtendedDaemonSetReplicaSet) bool {
 	// Check ERS status to detect if a Canary failed
 	if ers != nil && conditions.IsConditionTrue(&ers.Status, datadoghqv1alpha1.ConditionTypeCanaryFailed) {
 		return true
-	}
-
-	// Check also failed annotations if a user wanted to force a canary failure
-	if value, found := dsAnnotations[datadoghqv1alpha1.ExtendedDaemonSetCanaryFailedAnnotationKey]; found {
-		return value == datadoghqv1alpha1.ValueStringTrue
 	}
 
 	return false

--- a/controllers/extendeddaemonset_e2e_test.go
+++ b/controllers/extendeddaemonset_e2e_test.go
@@ -221,11 +221,6 @@ var _ = Describe("ExtendedDaemonSet e2e updates and recovery", func() {
 			Eventually(withEDS(key, eds, func() bool {
 				return eds.Status.State == datadoghqv1alpha1.ExtendedDaemonSetStatusStateRunning
 			}), timeout, interval).Should(BeTrue())
-
-			Eventually(withEDS(key, eds, func() bool {
-				_, found := eds.Annotations[datadoghqv1alpha1.ExtendedDaemonSetCanaryFailedAnnotationKey]
-				return found
-			}), timeout, interval).Should(BeFalse())
 		})
 
 		It("Should delete EDS", func() {
@@ -798,8 +793,6 @@ func clearCanaryAnnotations(eds *datadoghqv1alpha1.ExtendedDaemonSet) bool {
 		datadoghqv1alpha1.ExtendedDaemonSetCanaryPausedAnnotationKey,
 		datadoghqv1alpha1.ExtendedDaemonSetCanaryPausedReasonAnnotationKey,
 		datadoghqv1alpha1.ExtendedDaemonSetCanaryUnpausedAnnotationKey,
-		datadoghqv1alpha1.ExtendedDaemonSetCanaryFailedAnnotationKey,
-		datadoghqv1alpha1.ExtendedDaemonSetCanaryFailedReasonAnnotationKey,
 	}
 	var updated bool
 	for _, key := range keysToDelete {

--- a/controllers/extendeddaemonsetreplicaset/controller.go
+++ b/controllers/extendeddaemonsetreplicaset/controller.go
@@ -223,11 +223,6 @@ func (r *Reconciler) applyStrategy(logger logr.Logger, daemonset *datadoghqv1alp
 		conditions.UpdateExtendedDaemonSetReplicaSetStatusCondition(strategyParams.NewStatus, now, datadoghqv1alpha1.ConditionTypeActive, corev1.ConditionFalse, "", "", false, false)
 		logger.Info("manage canary deployment")
 		strategyResult, err = strategy.ManageCanaryDeployment(r.client, daemonset, strategyParams)
-	case strategy.ReplicaSetStatusCanaryFailed:
-		logger.Info("manage canary failed deployment")
-		strategyResult = &strategy.Result{
-			NewStatus: strategyParams.NewStatus.DeepCopy(),
-		}
 	case strategy.ReplicaSetStatusUnknown:
 		conditions.UpdateExtendedDaemonSetReplicaSetStatusCondition(strategyParams.NewStatus, now, datadoghqv1alpha1.ConditionTypeCanary, corev1.ConditionFalse, "", "", false, false)
 		conditions.UpdateExtendedDaemonSetReplicaSetStatusCondition(strategyParams.NewStatus, now, datadoghqv1alpha1.ConditionTypeActive, corev1.ConditionFalse, "", "", false, false)
@@ -460,6 +455,9 @@ func retrieveOwnerReference(obj *datadoghqv1alpha1.ExtendedDaemonSetReplicaSet) 
 	return "", fmt.Errorf("unable to retrieve the owner reference name")
 }
 
+// This method has the effect of deciding if the ERS should be ignored or something should be updated. Note that this
+// never returns strategy.ReplicaSetStatusCanaryFailed because that case does not need to be managed (if it is Failed, it has
+// already been processed).
 func retrieveReplicaSetStatus(daemonset *datadoghqv1alpha1.ExtendedDaemonSet, replicassetName string) strategy.ReplicaSetStatus {
 	switch daemonset.Status.ActiveReplicaSet {
 	case "":

--- a/controllers/extendeddaemonsetreplicaset/strategy/canary.go
+++ b/controllers/extendeddaemonsetreplicaset/strategy/canary.go
@@ -48,7 +48,8 @@ func manageCanaryStatus(annotations map[string]string, params *Parameters, now t
 	result.NewStatus = params.NewStatus.DeepCopy()
 	result.NewStatus.Status = string(ReplicaSetStatusCanary)
 
-	result.IsFailed = eds.IsCanaryDeploymentFailed(annotations, params.Replicaset)
+	// TODO: these are set here as well as in manageCanaryPodFailures. Consider simplifying.
+	result.IsFailed = eds.IsCanaryDeploymentFailed(params.Replicaset)
 	result.IsPaused, result.PausedReason = eds.IsCanaryDeploymentPaused(annotations, params.Replicaset)
 	result.IsUnpaused = eds.IsCanaryDeploymentUnpaused(annotations)
 

--- a/controllers/extendeddaemonsetreplicaset/strategy/utils.go
+++ b/controllers/extendeddaemonsetreplicaset/strategy/utils.go
@@ -24,8 +24,6 @@ import (
 	podutils "github.com/DataDog/extendeddaemonset/pkg/controller/utils/pod"
 )
 
-const valueTrue = "true"
-
 func compareCurrentPodWithNewPod(params *Parameters, pod *corev1.Pod, node *NodeItem) bool {
 	// check that the pod corresponds to the replicaset. if not return false
 	if !compareSpecTemplateMD5Hash(params.Replicaset.Spec.TemplateGeneration, pod) {
@@ -144,48 +142,6 @@ func manageUnscheduledPodNodes(pods []*corev1.Pod) []string {
 	}
 
 	return output
-}
-
-// annotateCanaryDeploymentWithReason annotates the Canary deployment with a reason.
-func annotateCanaryDeploymentWithReason(c client.Client, eds *datadoghqv1alpha1.ExtendedDaemonSet, valueKey string, reasonKey string, reason datadoghqv1alpha1.ExtendedDaemonSetStatusReason) error {
-	newEds := eds.DeepCopy()
-	if newEds.Annotations == nil {
-		newEds.Annotations = make(map[string]string)
-	}
-
-	if value, ok := newEds.Annotations[valueKey]; ok {
-		if value == valueTrue {
-			return nil
-		}
-	}
-
-	patch := client.MergeFrom(newEds.DeepCopy())
-	newEds.Annotations[valueKey] = valueTrue
-	newEds.Annotations[reasonKey] = string(reason)
-
-	return c.Patch(context.TODO(), newEds, patch)
-}
-
-// pauseCanaryDeployment updates two annotations so that the Canary deployment is marked as paused, along with a reason.
-func pauseCanaryDeployment(client client.Client, eds *datadoghqv1alpha1.ExtendedDaemonSet, reason datadoghqv1alpha1.ExtendedDaemonSetStatusReason) error {
-	return annotateCanaryDeploymentWithReason(
-		client,
-		eds,
-		datadoghqv1alpha1.ExtendedDaemonSetCanaryPausedAnnotationKey,
-		datadoghqv1alpha1.ExtendedDaemonSetCanaryPausedReasonAnnotationKey,
-		reason,
-	)
-}
-
-// failCanaryDeployment updates two annotations so that the Canary deployment is marked as failed, along with a reason.
-func failCanaryDeployment(client client.Client, eds *datadoghqv1alpha1.ExtendedDaemonSet, reason datadoghqv1alpha1.ExtendedDaemonSetStatusReason) error {
-	return annotateCanaryDeploymentWithReason(
-		client,
-		eds,
-		datadoghqv1alpha1.ExtendedDaemonSetCanaryFailedAnnotationKey,
-		datadoghqv1alpha1.ExtendedDaemonSetCanaryFailedReasonAnnotationKey,
-		reason,
-	)
 }
 
 // addPodLabel adds a given label to a pod, no-op if the pod is nil or if the label exists.

--- a/pkg/plugin/canary/pause.go
+++ b/pkg/plugin/canary/pause.go
@@ -165,6 +165,7 @@ func (o *pauseOptions) run() error {
 
 	newEds := eds.DeepCopy()
 
+	// TODO: update pause action to be less dependent on annotations as in the fail action
 	if newEds.Annotations == nil {
 		newEds.Annotations = make(map[string]string)
 	} else if isPaused, ok := newEds.Annotations[v1alpha1.ExtendedDaemonSetCanaryPausedAnnotationKey]; ok {


### PR DESCRIPTION
### What does this PR do?

- Update plugin `canary fail` cmd to update the status of the ERS instead of using EDS annotations.
- Remove references to canary fail annotations that are no longer needed
- Remove other methods that are not used
- Add TODOs for future PRs
 
### Motivation

It was noticed that the behavior of the `canary fail` command was peculiar; manual failures were not leading to canary pod deletions as expected. This seemed to be caused by the canary status being failed too quickly before the failed annotation could trigger the appropriate action.

Since failures are inherently tied to an ERS, it makes more sense to have the plugin modify the ERS instead. This more closely mimics the behavior for auto-failures and removes an extra step in managing the canary.

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

- Build the plugin with `make kubectl-eds`
- Apply the example extended daemonset `foo` (`k apply -f examples/foo-eds_v1.yaml`)
- Apply another extended daemonset to trigger the canary (`k apply -f examples/foo-eds_v2.yaml`)
- Fail the canary with `bin/kubectl-eds canary fail foo`
- Make sure that the failed ERS status conditions are updated to show
```
    Reason:                    Manually failed
    Status:                    True
    Type:                      Canary-Failed
```
- Make sure that the EDS status conditions are updated to show
```
    Message:                   canary failed with ers: foo-5wgn2
    Reason:                    CanaryFailed
    Status:                    False
    Type:                      Canary-Failed
```
- Make sure that the failed canary pods are cleared
