### PR TITLE
add node taint check for canary nodes, add missing test case for validation

### DIFF
--- a/api/v1alpha1/extendeddaemonset_validate_test.go
+++ b/api/v1alpha1/extendeddaemonset_validate_test.go
@@ -7,6 +7,7 @@ package v1alpha1
 
 import (
 	"testing"
+	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -50,6 +51,13 @@ func TestValidateExtendedDaemonSetSpec(t *testing.T) {
 	*validAutoPauseNoAutoFail.Strategy.Canary.AutoFail.Enabled = false
 	*validAutoPauseNoAutoFail.Strategy.Canary.AutoFail.MaxRestarts = 1
 
+	invalidCanaryTimeout := validWithCanary.DeepCopy()
+	*invalidCanaryTimeout.Strategy.Canary.AutoPause.Enabled = true
+	*invalidCanaryTimeout.Strategy.Canary.AutoFail.Enabled = true
+	invalidCanaryTimeout.Strategy.Canary.AutoFail.CanaryTimeout = &metav1.Duration{
+		Duration: 1 * time.Minute,
+	}
+
 	validManualValidationMode := validWithCanaryManualValidationMode.DeepCopy()
 	validManualValidationMode.Strategy.Canary.ValidationMode = ExtendedDaemonSetSpecStrategyCanaryValidationModeManual
 
@@ -82,6 +90,11 @@ func TestValidateExtendedDaemonSetSpec(t *testing.T) {
 			name: "invalid autoFail maxRestarts",
 			spec: invalidAutoFail,
 			err:  ErrInvalidAutoFailRestarts,
+		},
+		{
+			name: "invalid autoFail canaryTimeout",
+			spec: invalidCanaryTimeout,
+			err:  ErrInvalidCanaryTimeout,
 		},
 		{
 			name: "valid autoFail no autoPause",

--- a/controllers/extendeddaemonset/controller.go
+++ b/controllers/extendeddaemonset/controller.go
@@ -415,7 +415,9 @@ func (r *Reconciler) selectNodes(logger logr.Logger, daemonsetSpec *datadoghqv1a
 				antiAffinityKeysValues[antiAffinityKeysValue]++
 			}
 
-			currentNodes = append(currentNodes, node.Name)
+			if scheduler.CheckNodeFitness(logger, newPod, &node) {
+				currentNodes = append(currentNodes, node.Name)
+			}
 			// All nodes are found. We can exit now!
 			if len(currentNodes) == nbCanaryPod {
 				logger.V(1).Info("All nodes were found")


### PR DESCRIPTION
### What does this PR do?

During QA it was noticed that node taints are not handled properly when scheduling canary pods. This fixes the issue.

In addition, a test case is added that was missing for a recently added canary parameter (autoFail.canaryTimeout).

### Motivation

Fix

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Start a `kind` cluster with a tainted node (master nodes are tainted by default)
Deploy the EDS controller with `make deploy`
Deploy an example EDS that doesn't have any tolerations (edit examples/foo-eds_v1.yaml and then run `k apply -f examples/foo-eds_v1.yaml`)
Deploy another EDS to kick off the canary, also without any tolerations `examples/foo-eds_v2.yaml`
Make sure that the canary pod(s) gets scheduled 