### PR TITLE
Revert "[plugin] Set CGO_ENABLED=1 in goreleaser"

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -11,7 +11,7 @@ builds:
   goarch:
   - amd64
   env:
-  - CGO_ENABLED=1
+  - CGO_ENABLED=0
   main: ./cmd/kubectl-eds/main.go
   ldflags: -w -X ${BUILDINFOPKG}.Commit=${GIT_COMMIT} -X ${BUILDINFOPKG}.Version=${VERSION} -X ${BUILDINFOPKG}.BuildTime=${DATE} -s
   binary: kubectl-eds


### PR DESCRIPTION
Reverts DataDog/extendeddaemonset#146

Motivation: Goreleaser doesn't support cross-compilation with CGO enabled https://goreleaser.com/limitations/cgo/ - alternatively, we can use https://github.com/goreleaser/goreleaser-cross as recommended here https://goreleaser.com/cookbooks/cgo-and-crosscompiling/