### PR TITLE
Add darwin/arm64 entry to eds plugin released file

### DIFF
--- a/hack/release/eds-plugin-tmpl.yaml
+++ b/hack/release/eds-plugin-tmpl.yaml
@@ -11,7 +11,7 @@ spec:
   homepage: https://github.com/DataDog/extendeddaemonset
   platforms:
   - uri: https://github.com/DataDog/extendeddaemonset/releases/download/PLACEHOLDER_TAG/kubectl-eds_PLACEHOLDER_VERSION_darwin_amd64.zip
-    sha256: "PLACEHOLDER_SHA_DARWIN"
+    sha256: "PLACEHOLDER_SHA_DARWIN_AMD64"
     bin: kubectl-eds
     files:
     - from: kubectl-eds
@@ -22,6 +22,18 @@ spec:
       matchLabels:
         os: darwin
         arch: amd64
+  - uri: https://github.com/DataDog/extendeddaemonset/releases/download/PLACEHOLDER_TAG/kubectl-eds_PLACEHOLDER_VERSION_darwin_arm64.zip
+    sha256: "PLACEHOLDER_SHA_DARWIN_ARM64"
+    bin: kubectl-eds
+    files:
+    - from: kubectl-eds
+      to: .
+    - from: LICENSE
+      to: .
+    selector:
+      matchLabels:
+        os: darwin
+        arch: arm64
   - uri: https://github.com/DataDog/extendeddaemonset/releases/download/PLACEHOLDER_TAG/kubectl-eds_PLACEHOLDER_VERSION_linux_amd64.zip
     sha256: "PLACEHOLDER_SHA_LINUX"
     bin: kubectl-eds

--- a/hack/release/generate-plugin-manifest.sh
+++ b/hack/release/generate-plugin-manifest.sh
@@ -19,10 +19,12 @@ OUTPUT_FOLDER=$GIT_ROOT/dist
 TARBALL_NAME="$PLUGIN_NAME_$VERSION.tar.gz"
 
 DARWIN_AMD64=$(grep $PLUGIN_NAME $OUTPUT_FOLDER/checksums.txt  | grep "darwin_amd64" | awk '{print $1}')
+DARWIN_ARM64=$(grep $PLUGIN_NAME $OUTPUT_FOLDER/checksums.txt  | grep "darwin_arm64" | awk '{print $1}')
 WINDOWS_AMD64=$(grep $PLUGIN_NAME $OUTPUT_FOLDER/checksums.txt  | grep "windows_amd64" | awk '{print $1}')
 LINUX_AMD64=$(grep $PLUGIN_NAME $OUTPUT_FOLDER/checksums.txt  | grep "linux_amd64" | awk '{print $1}')
 
 echo "DARWIN_AMD64=$DARWIN_AMD64"
+echo "DARWIN_ARM64=$DARWIN_ARM64"
 echo "WINDOWS_AMD64=$WINDOWS_AMD64"
 echo "LINUX_AMD64=$LINUX_AMD64"
 
@@ -30,6 +32,7 @@ cp $GIT_ROOT/hack/release/eds-plugin-tmpl.yaml $OUTPUT_FOLDER/eds-plugin.yaml
 
 $SED "s/PLACEHOLDER_TAG/$TAG/g" $OUTPUT_FOLDER/eds-plugin.yaml
 $SED "s/PLACEHOLDER_VERSION/$VERSION/g" $OUTPUT_FOLDER/eds-plugin.yaml
-$SED "s/PLACEHOLDER_SHA_DARWIN/$DARWIN_AMD64/g" $OUTPUT_FOLDER/eds-plugin.yaml
+$SED "s/PLACEHOLDER_SHA_DARWIN_AMD64/$DARWIN_AMD64/g" $OUTPUT_FOLDER/eds-plugin.yaml
+$SED "s/PLACEHOLDER_SHA_DARWIN_ARM64/$DARWIN_ARM64/g" $OUTPUT_FOLDER/eds-plugin.yaml
 $SED "s/PLACEHOLDER_SHA_LINUX/$LINUX_AMD64/g" $OUTPUT_FOLDER/eds-plugin.yaml
 $SED "s/PLACEHOLDER_SHA_WINDOWS/$WINDOWS_AMD64/g" $OUTPUT_FOLDER/eds-plugin.yaml


### PR DESCRIPTION
### What does this PR do?

With https://github.com/DataDog/extendeddaemonset/releases/tag/v0.8.1-rc.1 we see that arm64 builds are now correctly generated but not included in `eds-plugin.yaml`.

This PR fixes this issue by including darwin/arm64 to this file. This is the most important in order to support M1/M2 macs.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details you may have to test your PR.
