### PR TITLE
fix(ci): update gitlab docker image

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,6 +6,7 @@ variables:
   GOPATH: "$CI_PROJECT_DIR/.cache"
   TARGET_TAG: v$CI_PIPELINE_ID-$CI_COMMIT_SHORT_SHA
   BUILD_DOCKER_REGISTRY: "486234852809.dkr.ecr.us-east-1.amazonaws.com/ci"
+  JOB_DOCKER_IMAGE: "486234852809.dkr.ecr.us-east-1.amazonaws.com/ci-containers-project:v13932656-a1b1db4-v1.0.0"
   DOCKER_REGISTRY_LOGIN_SSM_KEY: docker_hub_login
   DOCKER_REGISTRY_PWD_SSM_KEY: docker_hub_pwd
   DOCKER_REGISTRY_URL: docker.io
@@ -48,7 +49,7 @@ generate_code:
 build_eds_image_amd64:
   stage: image
   tags: ["runner:docker", "size:large"]
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/docker:v2718644-9ce6565-18.09.6-py3
+  image: $JOB_DOCKER_IMAGE
   variables:
     GOARCH: amd64
     TARGET_IMAGE: $BUILD_DOCKER_REGISTRY/$PROJECTNAME:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-amd64
@@ -64,7 +65,7 @@ build_eds_image_amd64:
 build_eds_image_arm64:
   stage: image
   tags: ["runner:docker-arm", "platform:arm64"]
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/docker:v2718787-3888eda-18.09.6-arm64-py3
+  image: $JOB_DOCKER_IMAGE
   variables:
     GOARCH: arm64
     TARGET_IMAGE: $BUILD_DOCKER_REGISTRY/$PROJECTNAME:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-arm64
@@ -81,7 +82,7 @@ build_eds_image_arm64:
 build_eds_check_image_amd64:
   stage: image
   tags: ["runner:docker", "size:large"]
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/docker:v2718644-9ce6565-18.09.6-py3
+  image: $JOB_DOCKER_IMAGE
   variables:
     GOARCH: amd64
     TARGET_IMAGE: $BUILD_DOCKER_REGISTRY/$PROJECTNAME_CHECK:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-amd64
@@ -97,7 +98,7 @@ build_eds_check_image_amd64:
 build_eds_check_image_arm64:
   stage: image
   tags: ["runner:docker-arm", "platform:arm64"]
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/docker:v2718787-3888eda-18.09.6-arm64-py3
+  image: $JOB_DOCKER_IMAGE
   variables:
     GOARCH: arm64
     TARGET_IMAGE: $BUILD_DOCKER_REGISTRY/$PROJECTNAME_CHECK:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-arm64


### PR DESCRIPTION
### What does this PR do?

Update the docker image used in the CI (gitlab) to use a more recent image that still exist in the registry. The new image should also be a multi-arch image

### Motivation

the current docker image was removed from the registry.

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

The CI (gitlab) should be green
