### PR TITLE
Bump go version in github actions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,5 +1,8 @@
 name: build
 
+env:
+  GO_VERSION: 1.19
+
 on:
   push:
 
@@ -19,7 +22,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.18
+          go-version: ${{ env.GO_VERSION }}
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v3
         with:
@@ -37,7 +40,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.17
+          go-version: ${{ env.GO_VERSION }}
       - name: Build
         uses: goreleaser/goreleaser-action@v3
         with:
@@ -54,7 +57,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.17
+          go-version: ${{ env.GO_VERSION }}
       - name: Build
         uses: goreleaser/goreleaser-action@v3
         with:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,5 +1,8 @@
 name: "CodeQL"
 
+env:
+  GO_VERSION: 1.19
+
 on:
   push:
     branches: [ main ]
@@ -36,6 +39,12 @@ jobs:
         # By default, queries listed here will override any specified in a config file.
         # Prefix the list here with "+" to use these queries and those in the config file.
         # queries: ./path/to/local/query, your-org/your-repo/queries@main
+
+    - name: Set up Go
+      uses: actions/setup-go@v1
+      with:
+        go-version: ${{ env.GO_VERSION }}
+      id: go
 
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     - name: Autobuild

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,5 +1,8 @@
 name: Release
 
+env:
+  GO_VERSION: 1.19
+
 on:
   push:
     branches:
@@ -25,7 +28,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.18
+          go-version: ${{ env.GO_VERSION }}
       - name: Get Latest Release
         id: latest_version
         uses: pozetroninc/github-action-get-latest-release@master
@@ -60,7 +63,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.17
+          go-version: ${{ env.GO_VERSION }}
       - name: Get Latest Release
         id: latest_version
         uses: pozetroninc/github-action-get-latest-release@master
@@ -94,7 +97,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.17
+          go-version: ${{ env.GO_VERSION }}
       - name: Get Latest Release
         id: latest_version
         uses: pozetroninc/github-action-get-latest-release@master

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -3,6 +3,7 @@ on: [push, pull_request]
 env:
   GO111MODULE: "on"
   PROJECTNAME: "extendeddaemonset"
+  GO_VERSION: 1.19
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -10,7 +11,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v1
       with:
-        go-version: 1.18
+        go-version: ${{ env.GO_VERSION }}
       id: go
     - name: Install required packages
       uses: mstksg/get-package@v1
@@ -45,7 +46,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v1
         with:
-          go-version: 1.18
+          go-version: ${{ env.GO_VERSION }}
         id: go
       - name: Install required packages
         uses: mstksg/get-package@v1

--- a/.gitignore
+++ b/.gitignore
@@ -85,3 +85,5 @@ tags
 .history
 # End of https://www.gitignore.io/api/go,vim,emacs,visualstudiocode
 /vendor
+# GoLand
+.idea


### PR DESCRIPTION
### What does this PR do?

Bump go version and use same go version across github actions.

### Motivation

Fix codeql build error in https://github.com/DataDog/extendeddaemonset/pull/160

### Additional Notes

Similar to https://github.com/DataDog/watermarkpodautoscaler/pull/183

### Describe your test plan

Write there any instructions and details you may have to test your PR.
