### PR TITLE
Keep track of pods already unhealthy before deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ extendeddaemonset-855cd7c679-gpmql   1/1     Running   0          2m11s
 
 #### `foo` ExtendedDaemonSet deployment
 
-Create the `foo` app with the ExtendedDaemonSet. For demo purposes, we'll use the `k8s.gcr.io/pause` Docker image, which is only awaiting a terminating signal. You can look at the `foo` application definition in the file `examples/foo-eds_v1.yaml`.
+Create the `foo` app with the ExtendedDaemonSet. For demo purposes, we'll use the `registry.k8s.io/pause` Docker image, which is only awaiting a terminating signal. You can look at the `foo` application definition in the file `examples/foo-eds_v1.yaml`.
 
 ```console
 $ kubectl apply -f examples/foo-eds_v1.yaml
@@ -111,9 +111,9 @@ Now we can try to update the ExtendedDaemonSet `foo`. The only difference betwee
 ```console
 $ diff examples/foo-eds_v1.yaml examples/foo-eds_v2.yaml
 17c17
-<         image: k8s.gcr.io/pause:3.0
+<         image: registry.k8s.io/pause:3.0
 ---
->         image: k8s.gcr.io/pause:3.1
+>         image: registry.k8s.io/pause:3.1
 
 $ kubectl apply -f examples/foo-eds_v2.yaml
 extendeddaemonset.datadoghq.com/foo configured

--- a/api/v1alpha1/const.go
+++ b/api/v1alpha1/const.go
@@ -14,6 +14,8 @@ const (
 	ExtendedDaemonSetReplicaSetCanaryLabelKey = "extendeddaemonsetreplicaset.datadoghq.com/canary"
 	// ExtendedDaemonSetReplicaSetCanaryLabelValue label value used to identify canary Pods.
 	ExtendedDaemonSetReplicaSetCanaryLabelValue = "true"
+	// ExtendedDaemonSetReplicaSetUnreadyPodsAnnotationKey annotation key used on ExtendedDaemonSetReplicaSet to detect the number of unready pods at the moment of creation of the ExtendedDaemonSetReplicaSet
+	ExtendedDaemonSetReplicaSetUnreadyPodsAnnotationKey = "extendeddaemonsetreplicaset.datadoghq.com/unready-pods"
 	// MD5ExtendedDaemonSetAnnotationKey annotation key use on Pods in order to identify which PodTemplateSpec have been used to generate it.
 	MD5ExtendedDaemonSetAnnotationKey = "extendeddaemonset.datadoghq.com/templatehash"
 	// ExtendedDaemonSetCanaryValidAnnotationKey annotation key used on Pods in order to detect if a canary deployment is considered valid.

--- a/config/samples/eds_v1alpha1_basic.yaml
+++ b/config/samples/eds_v1alpha1_basic.yaml
@@ -11,7 +11,7 @@ spec:
       maxParallelPodCreation: 10
       slowStartIntervalDuration: 2m
   template:
-    spec: 
+    spec:
       containers:
-      - name: daemon
-        image: k8s.gcr.io/pause:3.0
+        - name: daemon
+          image: registry.k8s.io/pause:3.0

--- a/config/samples/eds_v1alpha1_nodeexclusion.yaml
+++ b/config/samples/eds_v1alpha1_nodeexclusion.yaml
@@ -11,18 +11,18 @@ spec:
       maxParallelPodCreation: 1
       slowStartIntervalDuration: 1m
   template:
-    spec: 
+    spec:
       containers:
-      - name: daemon
-        image: k8s.gcr.io/pause:3.0
+        - name: daemon
+          image: registry.k8s.io/pause:3.0
       tolerations:
-      - operator: Exists
+        - operator: Exists
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
-            - matchExpressions:
-              - key: extendeddaemonset.datadoghq.com/exclude
-                operator: NotIn
-                values:
-                - foo
+              - matchExpressions:
+                  - key: extendeddaemonset.datadoghq.com/exclude
+                    operator: NotIn
+                    values:
+                      - foo

--- a/controllers/extendeddaemonset/controller_test.go
+++ b/controllers/extendeddaemonset/controller_test.go
@@ -554,7 +554,11 @@ func TestReconciler_createNewReplicaSet(t *testing.T) {
 				log:      testLogger,
 				recorder: eventBroadcaster.NewRecorder(scheme.Scheme, corev1.EventSource{Component: "TestReconciler_cleanupReplicaSet"}),
 			}
-			got, err := r.createNewReplicaSet(tt.args.logger, tt.args.daemonset)
+			got, err := r.createNewReplicaSet(tt.args.logger, tt.args.daemonset, podsCounterType{
+				Current:   3,
+				Ready:     2,
+				Available: 1,
+			})
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Reconciler.createNewReplicaSet() error = %v, wantErr %v", err, tt.wantErr)
 

--- a/controllers/extendeddaemonset_test.go
+++ b/controllers/extendeddaemonset_test.go
@@ -59,7 +59,7 @@ var _ = Describe("ExtendedDaemonSet Controller", func() {
 				},
 				ReconcileFrequency: reconcileFrequency,
 			}
-			eds := testutils.NewExtendedDaemonset(namespace, name, "k8s.gcr.io/pause:latest", edsOptions)
+			eds := testutils.NewExtendedDaemonset(namespace, name, "registry.k8s.io/pause:latest", edsOptions)
 			Expect(k8sClient.Create(ctx, eds)).Should(Succeed())
 
 			eds = &datadoghqv1alpha1.ExtendedDaemonSet{}
@@ -122,7 +122,7 @@ var _ = Describe("ExtendedDaemonSet Rolling Update Pause", func() {
 				},
 				ReconcileFrequency: reconcileFrequency,
 			}
-			eds := testutils.NewExtendedDaemonset(namespace, name, "k8s.gcr.io/pause:latest", edsOptions)
+			eds := testutils.NewExtendedDaemonset(namespace, name, "registry.k8s.io/pause:latest", edsOptions)
 			Expect(k8sClient.Create(ctx, eds)).Should(Succeed())
 
 			eds = &datadoghqv1alpha1.ExtendedDaemonSet{}
@@ -157,7 +157,7 @@ var _ = Describe("ExtendedDaemonSet Rolling Update Pause", func() {
 		It("Should not deploy with paused EDS", func() {
 			eds := &datadoghqv1alpha1.ExtendedDaemonSet{}
 			Expect(k8sClient.Get(ctx, key, eds)).Should(Succeed())
-			eds.Spec.Template.Spec.Containers[0].Image = "k8s.gcr.io/pause:3.0" // Trigger a new ERS
+			eds.Spec.Template.Spec.Containers[0].Image = "registry.k8s.io/pause:3.0" // Trigger a new ERS
 			if eds.Annotations == nil {
 				eds.Annotations = make(map[string]string)
 			}
@@ -321,7 +321,7 @@ var _ = Describe("ExtendedDaemonSet Rollout Freeze", func() {
 				ReconcileFrequency: reconcileFrequency,
 				ExtraAnnotations:   map[string]string{"extendeddaemonset.datadoghq.com/rollout-frozen": "true"},
 			}
-			eds := testutils.NewExtendedDaemonset(namespace, name, "k8s.gcr.io/pause:latest", edsOptions)
+			eds := testutils.NewExtendedDaemonset(namespace, name, "registry.k8s.io/pause:latest", edsOptions)
 			Expect(k8sClient.Create(ctx, eds)).Should(Succeed())
 
 			eds = &datadoghqv1alpha1.ExtendedDaemonSet{}

--- a/controllers/extendeddaemonsetreplicaset/strategy/limits/limits.go
+++ b/controllers/extendeddaemonsetreplicaset/strategy/limits/limits.go
@@ -14,6 +14,7 @@ type Parameters struct {
 	NbOldAvailablesPod  int
 	NbCreatedPod        int
 	NbUnresponsiveNodes int
+	NbUnreadyPods       int
 
 	MaxPodCreation      int
 	MaxUnavailablePod   int
@@ -37,7 +38,12 @@ func CalculatePodToCreateAndDelete(params Parameters) (nbCreation, nbDeletion in
 		effectiveUnresponsive = params.MaxUnschedulablePod
 	}
 
-	nbDeletion = params.MaxUnavailablePod - (params.NbNodes - effectiveUnresponsive - params.NbAvailablesPod - params.NbOldAvailablesPod)
+	nbDeletion = params.MaxUnavailablePod - (params.NbNodes - effectiveUnresponsive - params.NbAvailablesPod - params.NbOldAvailablesPod) + params.NbUnreadyPods
+
+	if nbDeletion > params.MaxUnavailablePod {
+		nbDeletion = params.MaxUnavailablePod
+	}
+
 	if nbDeletion < 0 {
 		nbDeletion = 0
 	}

--- a/controllers/extendeddaemonsetreplicaset/strategy/limits/limits_test.go
+++ b/controllers/extendeddaemonsetreplicaset/strategy/limits/limits_test.go
@@ -211,6 +211,23 @@ func TestCalculatePodToCreateAndDelete(t *testing.T) {
 			wantNbCreation: 17,
 			wantNbDeletion: 2,
 		},
+		{
+			name: "10 nodes, 10 pods exist and 7 ready, 3 initially unready pods, maxPodCreation=5,MaxUnavailablePod=3",
+			args: args{
+				params: Parameters{
+					NbNodes: 10,
+					NbPods:  10,
+
+					NbUnreadyPods:     3,
+					NbAvailablesPod:   7,
+					NbCreatedPod:      10,
+					MaxUnavailablePod: 3,
+					MaxPodCreation:    5,
+				},
+			},
+			wantNbCreation: 0,
+			wantNbDeletion: 3,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/controllers/extendeddaemonsetreplicaset/strategy/rollingupdate_test.go
+++ b/controllers/extendeddaemonsetreplicaset/strategy/rollingupdate_test.go
@@ -48,6 +48,11 @@ func TestManageDeployment(t *testing.T) {
 					RollingUpdate: *defaultRollingUpdate,
 				},
 				Replicaset: &datadoghqv1alpha1.ExtendedDaemonSetReplicaSet{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							datadoghqv1alpha1.ExtendedDaemonSetReplicaSetUnreadyPodsAnnotationKey: "0",
+						},
+					},
 					Status: datadoghqv1alpha1.ExtendedDaemonSetReplicaSetStatus{
 						Conditions: []datadoghqv1alpha1.ExtendedDaemonSetReplicaSetCondition{
 							{
@@ -86,6 +91,11 @@ func TestManageDeployment(t *testing.T) {
 					RollingUpdate: *defaultRollingUpdate,
 				},
 				Replicaset: &datadoghqv1alpha1.ExtendedDaemonSetReplicaSet{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							datadoghqv1alpha1.ExtendedDaemonSetReplicaSetUnreadyPodsAnnotationKey: "0",
+						},
+					},
 					Status: datadoghqv1alpha1.ExtendedDaemonSetReplicaSetStatus{
 						Conditions: []datadoghqv1alpha1.ExtendedDaemonSetReplicaSetCondition{
 							{
@@ -134,6 +144,11 @@ func TestManageDeployment(t *testing.T) {
 					RollingUpdate: *defaultRollingUpdate,
 				},
 				Replicaset: &datadoghqv1alpha1.ExtendedDaemonSetReplicaSet{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							datadoghqv1alpha1.ExtendedDaemonSetReplicaSetUnreadyPodsAnnotationKey: "0",
+						},
+					},
 					Status: datadoghqv1alpha1.ExtendedDaemonSetReplicaSetStatus{
 						Conditions: []datadoghqv1alpha1.ExtendedDaemonSetReplicaSetCondition{
 							{
@@ -188,6 +203,11 @@ func TestManageDeployment(t *testing.T) {
 					RollingUpdate: *defaultRollingUpdate,
 				},
 				Replicaset: &datadoghqv1alpha1.ExtendedDaemonSetReplicaSet{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							datadoghqv1alpha1.ExtendedDaemonSetReplicaSetUnreadyPodsAnnotationKey: "0",
+						},
+					},
 					Status: datadoghqv1alpha1.ExtendedDaemonSetReplicaSetStatus{
 						Conditions: []datadoghqv1alpha1.ExtendedDaemonSetReplicaSetCondition{
 							{
@@ -242,6 +262,11 @@ func TestManageDeployment(t *testing.T) {
 					RollingUpdate: *defaultRollingUpdate,
 				},
 				Replicaset: &datadoghqv1alpha1.ExtendedDaemonSetReplicaSet{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							datadoghqv1alpha1.ExtendedDaemonSetReplicaSetUnreadyPodsAnnotationKey: "0",
+						},
+					},
 					Status: datadoghqv1alpha1.ExtendedDaemonSetReplicaSetStatus{
 						Conditions: []datadoghqv1alpha1.ExtendedDaemonSetReplicaSetCondition{
 							{

--- a/examples/failure-cases/foo-eds_image_pull_error.yaml
+++ b/examples/failure-cases/foo-eds_image_pull_error.yaml
@@ -22,7 +22,7 @@ spec:
   template:
     spec:
       containers:
-      - name: daemon
-        image: k8s.gcr.io/missing
+        - name: daemon
+          image: registry.k8s.io/missing
       tolerations:
-      - operator: Exists
+        - operator: Exists

--- a/examples/failure-cases/foo-eds_restarts.yaml
+++ b/examples/failure-cases/foo-eds_restarts.yaml
@@ -22,8 +22,8 @@ spec:
   template:
     spec:
       containers:
-      - name: daemon
-        image: k8s.gcr.io/pause:3.1
-        command: ["does", "-not", "-exist"]
+        - name: daemon
+          image: registry.k8s.io/pause:3.1
+          command: ["does", "-not", "-exist"]
       tolerations:
-      - operator: Exists
+        - operator: Exists

--- a/examples/foo-eds_exclude-node.yaml
+++ b/examples/foo-eds_exclude-node.yaml
@@ -11,18 +11,18 @@ spec:
       maxParallelPodCreation: 1
       slowStartIntervalDuration: 1m
   template:
-    spec: 
+    spec:
       containers:
-      - name: daemon
-        image: k8s.gcr.io/pause:3.0
+        - name: daemon
+          image: registry.k8s.io/pause:3.0
       tolerations:
-      - operator: Exists
+        - operator: Exists
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
-            - matchExpressions:
-              - key: extendeddaemonset.datadoghq.com/exclude
-                operator: NotIn
-                values:
-                - foo
+              - matchExpressions:
+                  - key: extendeddaemonset.datadoghq.com/exclude
+                    operator: NotIn
+                    values:
+                      - foo

--- a/examples/foo-eds_v1.yaml
+++ b/examples/foo-eds_v1.yaml
@@ -18,9 +18,9 @@ spec:
       maxUnavailable: 2
       slowStartIntervalDuration: 1m
   template:
-    spec: 
+    spec:
       containers:
-      - name: daemon
-        image: k8s.gcr.io/pause:3.0
+        - name: daemon
+          image: registry.k8s.io/pause:3.0
       tolerations:
-      - operator: Exists
+        - operator: Exists

--- a/examples/foo-eds_v2.yaml
+++ b/examples/foo-eds_v2.yaml
@@ -20,7 +20,7 @@ spec:
   template:
     spec:
       containers:
-      - name: daemon
-        image: k8s.gcr.io/pause:3.1
+        - name: daemon
+          image: registry.k8s.io/pause:3.1
       tolerations:
-      - operator: Exists
+        - operator: Exists

--- a/hack/release/cluster-service-version-patch.yaml
+++ b/hack/release/cluster-service-version-patch.yaml
@@ -6,7 +6,7 @@ metadata:
     containerImage: datadog/extendeddaemonset:0.2.0
     description: |-
       ExtendedDaemonSet aims to provide a new implementation of the Kubernetes DaemonSet resource with key features:
-      
+
         * Canary Deployment: Deploy a new DaemonSet version with only a few nodes.
         * Custom Rolling Update: Improve the default rolling update logic available in Kubernetes batch/v1 Daemonset.
     repository: https://github.com/DataDog/extendeddaemonset
@@ -34,7 +34,7 @@ metadata:
               "containers": [
                 {
                   "name": "daemon",
-                  "image": "k8s.gcr.io/pause:3.0"
+                  "image": "registry.k8s.io/pause:3.0"
                 }
               ],
               "tolerations": [
@@ -47,20 +47,20 @@ metadata:
         }
       }]
 spec:
-  description: ExtendedDaemonSet aims to provide a new implementation of 
+  description: ExtendedDaemonSet aims to provide a new implementation of
     the Kubernetes DaemonSet resource with key features such as canary deployment
     and custom rolling update strategy.
   icon:
   keywords:
-  - Daemonset
-  - Canary
-  - ExtendedDaemonset
-  - Deployment
+    - Daemonset
+    - Canary
+    - ExtendedDaemonset
+    - Deployment
   links:
-  - name: Documentation
-    url: https://github.com/DataDog/extendeddaemonset
+    - name: Documentation
+      url: https://github.com/DataDog/extendeddaemonset
   maintainers:
-  - email: cedric@datadoghq.com
-    name: Cedric Lamoriniere
+    - email: cedric@datadoghq.com
+      name: Cedric Lamoriniere
   provider:
     name: Datadog


### PR DESCRIPTION
### What does this PR do?

This PR enhances the extended daemon set to keep track of pods that were already unhealthy before deployment.

[Jira Card](https://datadoghq.atlassian.net/jira/software/projects/CONT/boards/167?selectedIssue=CONT-4075)

### Motivation

The EDS controller like the Daemonset controller is configured to limit the number of daemonset pod un-ready during a rollout. For example the rollout strategy can be not more than 5% of pod unready. 
But if before a rollout start 4% of the existing pods are not ready, it means that the controller can also update 1% at the same time (5%-4%= 1%) which slow down the deployment. and even in some case block the deployment (if more than 5% of the pods are unready before the rollout).

If the EDS could keep track of the number of pods that were initially unhealthy before deployment, it would be able to keep the rollout strategy unaffected (and thus not blocked or slowed-down) by the pods that were previously unhealthy.

### Changes Made
- The number of unhealthy pods is added to the extendeddaemonset replicaset upon creation as an annotation `unready-pods`.
-  When calculating the number of pods that can be deleted in `limits.go`, the number of initially unhealthy pods (which is stored in the annotations of the ERS) is used to compensate for this difference in the calculation.

### Additional Notes
- The image `k8s.gcr.io/pause:latest` was used in the integration tests. However this image doesn't work on arm architecture, this is why I changed it to `k8s.gcr.io/pause:3.0`.
- In case the unready pods annotation doesn't exist for some reason, the reconciler will fallback to the default behaviour (i.e the rollout will be slowed down / blocked in case there were many pods unready before rollout)

### Describe your test plan
- Unit Testing:
    - The function `CalculatePodToCreateAndDelete` in `limits.go` was unit-tested in `limits_test.go` to ensure that the pods that were already unhealthy are taken into consideration.
    - We can run the unit tests by executing `make test`
- E2E Testing:
    - Integration testing was implemented
    - Deploy a kind cluster with a few nodes
    - Run the E2E test using `make e2e`
    - The E2E test of this change includes the following:
       - Creating an EDS with a corrupted image
       - This results in all pods of the EDS being unhealthy
       - Edit the EDS by setting a valid container image in the pod template (e.g. `k8s.gcr.io/pause:3.0`)
       - Launch the deployment
       - Ensure that the rollout is not blocked and that the EDS becomes finally in the Running state, with 1 active ERS and all pods are healthy and running
- QA Testing:
    - Create a kind cluster with few nodes (at least 3)
    - First create a configmap by running `kubectl create configmap example-configmap`
    - Run `make install` to install the CRDs
    - Run the controller (e.g by running `make run`, attention you should add `LeaderElectionNamespace: "kube-system"` to the created manager in `main.go` for this to work)
    - Create an EDS with the following description:
        ```apiVersion: datadoghq.com/v1alpha1
              kind: ExtendedDaemonSet
              metadata:
                   name: foo
              spec:
                strategy:
                  canary:
                    replicas: 1
                    duration: 5m
                    autoFail:
                      enabled: true
                      canaryTimeout: 10m
                    autoPause:
                      enabled: true
                      maxRestarts: 5
                  rollingUpdate:
                    maxParallelPodCreation: 1
                    maxUnavailable: 2
                    slowStartIntervalDuration: 1m
                template:
                  spec:
                    containers:
                      - name: daemon
                        image: k8s.gcr.io/pause:3.0
                        envFrom:
                          - configMapRef:
                              name: example-configmap
                    tolerations:
                      - operator: Exists
    - When the pods are up and running, delete the configmap by running `kubectl delete configmap example-configmap`
    - Delete some pods (at least 3)
    - The ERS will try to recreate the pods, but the created pods will become unhealthy because the configmap is deleted
    - Launch a deployment using the same definition of the EDS, but remove the `envFrom` property from the pod template
   - Check the status of the deployment process by running `kubectl get ers --watch`. You should see 1 canary and the active replicaset
   - After 5 minutes, the rollout should start and the deployment should not be blocked by the pods that are already unhealthy.
   - You should end up with 1 active ERS having all pods healthy and running