### PR TITLE
Update container start error so it respects `MaxSlowStartDuration`

### DIFF
--- a/controllers/extendeddaemonset_e2e_test.go
+++ b/controllers/extendeddaemonset_e2e_test.go
@@ -953,7 +953,7 @@ var _ = Describe("ExtendedDaemonSet e2e Pod within MaxSlowStartDuration", func()
 		}
 		Eventually(withList(listOptions, pods, "EDS pods", func() bool {
 			return len(pods.Items) == 0
-		}), timeout, interval).Should(BeTrue(), "All EDS pods should be destroyed")
+		}), longTimeout, interval).Should(BeTrue(), "All EDS pods should be destroyed")
 
 		erslist := &datadoghqv1alpha1.ExtendedDaemonSetReplicaSetList{}
 		Eventually(withList(listOptions, erslist, "ERS instances", func() bool {

--- a/controllers/extendeddaemonset_e2e_test.go
+++ b/controllers/extendeddaemonset_e2e_test.go
@@ -998,7 +998,7 @@ var _ = Describe("ExtendedDaemonSet e2e Pod within MaxSlowStartDuration", func()
 			},
 		}
 		Eventually(withList(listOptions, pods, "EDS pods", func() bool {
-			if len(pods.Items) < 0 {
+			if len(pods.Items) == 0 {
 				return false
 			}
 			for _, item := range pods.Items {

--- a/controllers/extendeddaemonset_e2e_test.go
+++ b/controllers/extendeddaemonset_e2e_test.go
@@ -1015,31 +1015,8 @@ var _ = Describe("ExtendedDaemonSet e2e PodCannotStart condition within max ss",
 
 		cond := edsconditions.GetExtendedDaemonSetStatusCondition(&eds.Status, datadoghqv1alpha1.ConditionTypeEDSCanaryPaused)
 		Expect(cond).Should(BeNil())
-
-		updateFunc := func(eds *datadoghqv1alpha1.ExtendedDaemonSet) {
-			eds.Spec.Template.Spec.Containers[0].Image = fmt.Sprintf("k8s.gcr.io/pause:3.1")
-		}
-		Eventually(updateEDS(k8sClient, key, updateFunc), timeout, interval).Should(
-			BeTrue(),
-			func() string { return "Unable to update the EDS" },
-		)
-
-		eds = &datadoghqv1alpha1.ExtendedDaemonSet{}
-		Expect(k8sClient.Get(ctx, key, eds)).Should(Succeed())
-		info("EDS status:\n%s\n", spew.Sdump(eds.Status))
-
 		Eventually(withEDS(key, eds, func() bool {
 			return eds.Status.State == datadoghqv1alpha1.ExtendedDaemonSetStatusStateRunning
-		}), timeout, interval).Should(BeTrue())
-
-		nodeList := &corev1.NodeList{}
-		ers := &datadoghqv1alpha1.ExtendedDaemonSetReplicaSet{}
-		ersKey := types.NamespacedName{
-			Namespace: namespace,
-			Name:      eds.Status.ActiveReplicaSet,
-		}
-		Eventually(withERS(ersKey, ers, func() bool {
-			return ers.Status.Status == "active" && int(ers.Status.Available) == len(nodeList.Items)
 		}), timeout, interval).Should(BeTrue())
 	}
 

--- a/controllers/extendeddaemonset_e2e_test.go
+++ b/controllers/extendeddaemonset_e2e_test.go
@@ -1000,8 +1000,12 @@ var _ = Describe("ExtendedDaemonSet e2e Pod within MaxSlowStartDuration", func()
 		Eventually(withList(listOptions, pods, "EDS pods", func() bool {
 			if len(pods.Items) > 0 {
 				for _, item := range pods.Items {
-					if len(item.Status.ContainerStatuses) > 0 && item.Status.ContainerStatuses[0].State.Waiting != nil && (pod.IsCannotStartReason(item.Status.ContainerStatuses[0].State.Waiting.Reason)) && pods.Items[0].Status.ContainerStatuses[0].State.Waiting.Reason == expectedReason {
-						return true
+					if len(item.Status.ContainerStatuses) > 0 {
+						for _, status := range item.Status.ContainerStatuses {
+							if status.State.Waiting != nil && (pod.IsCannotStartReason(status.State.Waiting.Reason)) && status.State.Waiting.Reason == expectedReason {
+								return true
+							}
+						}
 					}
 				}
 			}

--- a/controllers/extendeddaemonset_e2e_test.go
+++ b/controllers/extendeddaemonset_e2e_test.go
@@ -998,17 +998,20 @@ var _ = Describe("ExtendedDaemonSet e2e Pod within MaxSlowStartDuration", func()
 			},
 		}
 		Eventually(withList(listOptions, pods, "EDS pods", func() bool {
-			if len(pods.Items) > 0 {
-				for _, item := range pods.Items {
-					if len(item.Status.ContainerStatuses) > 0 {
-						for _, status := range item.Status.ContainerStatuses {
-							if status.State.Waiting != nil {
-								info("EDS %s - pod %s is in state %s\n", name, item.Name, status.State.Waiting.Reason)
-							}
-							if status.State.Waiting != nil && (pod.IsCannotStartReason(status.State.Waiting.Reason)) && status.State.Waiting.Reason == expectedReason {
-								return true
-							}
-						}
+			if len(pods.Items) < 0 {
+				return false
+			}
+			for _, item := range pods.Items {
+				if len(item.Status.ContainerStatuses) == 0 {
+					continue
+				}
+				for _, status := range item.Status.ContainerStatuses {
+					if status.State.Waiting == nil {
+						continue
+					}
+					info("EDS %s - pod %s is in state %s\n", name, item.Name, status.State.Waiting.Reason)
+					if (pod.IsCannotStartReason(status.State.Waiting.Reason)) && status.State.Waiting.Reason == expectedReason {
+						return true
 					}
 				}
 			}

--- a/controllers/extendeddaemonset_e2e_test.go
+++ b/controllers/extendeddaemonset_e2e_test.go
@@ -1002,6 +1002,9 @@ var _ = Describe("ExtendedDaemonSet e2e Pod within MaxSlowStartDuration", func()
 				for _, item := range pods.Items {
 					if len(item.Status.ContainerStatuses) > 0 {
 						for _, status := range item.Status.ContainerStatuses {
+							if status.State.Waiting != nil {
+								info("EDS %s - pod %s is in state %s\n", name, item.Name, status.State.Waiting.Reason)
+							}
 							if status.State.Waiting != nil && (pod.IsCannotStartReason(status.State.Waiting.Reason)) && status.State.Waiting.Reason == expectedReason {
 								return true
 							}

--- a/controllers/extendeddaemonset_e2e_test.go
+++ b/controllers/extendeddaemonset_e2e_test.go
@@ -939,8 +939,8 @@ var _ = Describe("ExtendedDaemonSet e2e Pod within MaxSlowStartDuration", func()
 		info("AfterEach: Destroying EDS %s\n", name)
 		eds := &datadoghqv1alpha1.ExtendedDaemonSet{}
 		Expect(k8sClient.Get(ctx, key, eds)).Should(Succeed())
-		// info("AfterEach: Destroying EDS %s - canary replicaset: %s\n", name, eds.Status.Canary.ReplicaSet)
-		// info("AfterEach: Destroying EDS %s - active replicaset: %s\n", name, eds.Status.ActiveReplicaSet)
+		info("AfterEach: Destroying EDS %s - canary replicaset: %s\n", name, eds.Status.Canary.ReplicaSet)
+		info("AfterEach: Destroying EDS %s - active replicaset: %s\n", name, eds.Status.ActiveReplicaSet)
 
 		Eventually(deleteEDS(k8sClient, key), timeout, interval).Should(BeTrue(), "EDS should be deleted")
 
@@ -998,7 +998,11 @@ var _ = Describe("ExtendedDaemonSet e2e Pod within MaxSlowStartDuration", func()
 			},
 		}
 		Eventually(withList(listOptions, pods, "EDS pods", func() bool {
-			return len(pods.Items) > 0 && len(pods.Items[0].Status.ContainerStatuses) > 0 && pods.Items[0].Status.ContainerStatuses[0].State.Waiting != nil && (pod.IsCannotStartReason(pods.Items[0].Status.ContainerStatuses[0].State.Waiting.Reason) && pods.Items[0].Status.ContainerStatuses[0].State.Waiting.Reason == expectedReason)
+			cond := len(pods.Items) > 0 && len(pods.Items[0].Status.ContainerStatuses) > 0 && pods.Items[0].Status.ContainerStatuses[0].State.Waiting != nil && (pod.IsCannotStartReason(pods.Items[0].Status.ContainerStatuses[0].State.Waiting.Reason))
+			if cond {
+				info("EDS %s - cannot start reason: %s\n", name, pods.Items[0].Status.ContainerStatuses[0].State.Waiting.Reason)
+			}
+			return cond
 		}), longTimeout, interval).Should(BeTrue(), "All EDS pods should be destroyed")
 
 		Expect(eds.Status.State == datadoghqv1alpha1.ExtendedDaemonSetStatusStateCanaryPaused).Should(BeFalse())

--- a/controllers/extendeddaemonset_e2e_test.go
+++ b/controllers/extendeddaemonset_e2e_test.go
@@ -956,7 +956,7 @@ func updateEDS(k8sclient client.Client, key types.NamespacedName, updateFunc fun
 	}
 }
 
-var _ = Describe("ExtendedDaemonSet e2e PodCannotStart condition within max ss", func() {
+var _ = Describe("ExtendedDaemonSet e2e PodCannotStart condition within MaxSlowStartDuration", func() {
 	var (
 		name string
 		key  types.NamespacedName
@@ -1021,7 +1021,7 @@ var _ = Describe("ExtendedDaemonSet e2e PodCannotStart condition within max ss",
 	}
 
 	Context("When pod has container config error", func() {
-		It("Should not auto-pause canary", func() {
+		It("Should not auto-pause canary if error occurs within MaxSlowStartDuration", func() {
 			restartOnPodStartFailureWithinMaxSlowStartDuration(func(eds *datadoghqv1alpha1.ExtendedDaemonSet) {
 				eds.Spec.Template.Spec.Containers[0].Image = fmt.Sprintf("gcr.io/google-containers/alpine-with-bash:1.0")
 				eds.Spec.Template.Spec.Containers[0].Command = []string{


### PR DESCRIPTION
### What does this PR do?

During canary, if an error occurs during pod creation within the `MaxSlowStartDuration`, the pod is no longer auto-paused. If `MaxSlowStartDuration` is not defined, the behavior is unchanged.

### Motivation

Many recent deployments have been paused due to a `CreateContainerConfigError` - `Error: failed to sync secret cache: timed out waiting for the condition`. Though this error is sometimes rectified a few seconds/minutes after it is first raised, the deployment remains paused, thus slowing down releases, etc. This change is being introduced in hopes of avoiding cases where canary is paused although the issue no longer exists.

### Additional Notes

Should a default value for `maxSlowStartDuration` be set for our clusters? 

### Describe your test plan

Unit tests and E2E test were included with the change. I also deployed these changes to a few staging clusters and did not see the issue of a paused canary arising in those clusters.
