### PR TITLE
Fail check-eds if canary is marked as failed

### DIFF
--- a/cmd/check-eds/upgrade/upgrade.go
+++ b/cmd/check-eds/upgrade/upgrade.go
@@ -158,8 +158,27 @@ func (o *Options) Run() error {
 			return false, fmt.Errorf("unable to get ExtendedDaemonSet, err: %w", err)
 		}
 
-		if eds.Status.State == v1alpha1.ExtendedDaemonSetStatusStateCanaryFailed {
-			return false, fmt.Errorf("canary marked as failed")
+		// We need to look at the activeReplicaSet of the current ExtendedDaemonSet object, and look at the creationTimestamp of
+		// that replicaset. If the creationTimestamp is older than the last occurrance of the "CanaryFailed" condition of the ExtendedDaemonSet,
+		// it is safe to assume that the canary failed and we should fail this check.
+		var canaryFailedConditionPresent bool
+		var canaryFailedCondition v1alpha1.ExtendedDaemonSetCondition
+		for _, condition := range eds.Status.Conditions {
+			if condition.Type == v1alpha1.ConditionTypeEDSCanaryFailed {
+				canaryFailedConditionPresent = true
+				canaryFailedCondition = condition
+				break
+			}
+		}
+
+		if canaryFailedConditionPresent {
+			ers := &v1alpha1.ExtendedDaemonSetReplicaSet{}
+			err = o.client.Get(context.TODO(), client.ObjectKey{Namespace: o.userNamespace, Name: eds.Status.ActiveReplicaSet}, ers)
+			if err == nil {
+				if ers.CreationTimestamp.Before(&canaryFailedCondition.LastTransitionTime) {
+					return false, fmt.Errorf("active canary has a creation timestamp before the last CanaryFailed condition, meaning the deployment failed")
+				}
+			}
 		}
 
 		if eds.Status.Canary != nil {

--- a/cmd/check-eds/upgrade/upgrade.go
+++ b/cmd/check-eds/upgrade/upgrade.go
@@ -173,6 +173,7 @@ func (o *Options) Run() error {
 			if condition.Type == v1alpha1.ConditionTypeEDSCanaryFailed {
 				canaryFailedConditionPresent = true
 				canaryFailedCondition = condition
+				o.printOutf("CanaryFailed condition found")
 				break
 			}
 		}
@@ -181,9 +182,12 @@ func (o *Options) Run() error {
 			ers := &v1alpha1.ExtendedDaemonSetReplicaSet{}
 			err = o.client.Get(context.TODO(), client.ObjectKey{Namespace: o.userNamespace, Name: eds.Status.ActiveReplicaSet}, ers)
 			if err == nil {
+				o.printOutf("active canary creation timestamp: %s; failed canary timestamp: %s", ers.CreationTimestamp.String(), canaryFailedCondition.LastTransitionTime.String())
 				if ers.CreationTimestamp.Before(&canaryFailedCondition.LastTransitionTime) {
 					return false, fmt.Errorf("active canary has a creation timestamp before the last CanaryFailed condition, meaning the deployment failed")
 				}
+			} else {
+				o.printOutf("error getting replicaset %s: %s", eds.Status.ActiveReplicaSet, err.Error())
 			}
 		}
 

--- a/cmd/check-eds/upgrade/upgrade.go
+++ b/cmd/check-eds/upgrade/upgrade.go
@@ -165,7 +165,7 @@ func (o *Options) Run() error {
 		}
 
 		// We need to look at the activeReplicaSet of the current ExtendedDaemonSet object, and look at the creationTimestamp of
-		// that replicaset. If the creationTimestamp is older than the last occurrance of the "CanaryFailed" condition of the ExtendedDaemonSet,
+		// that replicaset. If the creationTimestamp is older than the last occurrence of the "CanaryFailed" condition of the ExtendedDaemonSet,
 		// it is safe to assume that the canary failed and we should fail this check.
 		var canaryFailedConditionPresent bool
 		var canaryFailedCondition v1alpha1.ExtendedDaemonSetCondition

--- a/cmd/check-eds/upgrade/upgrade.go
+++ b/cmd/check-eds/upgrade/upgrade.go
@@ -173,7 +173,6 @@ func (o *Options) Run() error {
 			if condition.Type == v1alpha1.ConditionTypeEDSCanaryFailed {
 				canaryFailedConditionPresent = true
 				canaryFailedCondition = condition
-				o.printOutf("CanaryFailed condition found")
 				break
 			}
 		}
@@ -182,7 +181,6 @@ func (o *Options) Run() error {
 			ers := &v1alpha1.ExtendedDaemonSetReplicaSet{}
 			err = o.client.Get(context.TODO(), client.ObjectKey{Namespace: o.userNamespace, Name: eds.Status.ActiveReplicaSet}, ers)
 			if err == nil {
-				o.printOutf("active canary creation timestamp: %s; failed canary timestamp: %s", ers.CreationTimestamp.String(), canaryFailedCondition.LastTransitionTime.String())
 				if ers.CreationTimestamp.Before(&canaryFailedCondition.LastTransitionTime) {
 					return false, fmt.Errorf("active canary has a creation timestamp before the last CanaryFailed condition, meaning the deployment failed")
 				}

--- a/cmd/check-eds/upgrade/upgrade.go
+++ b/cmd/check-eds/upgrade/upgrade.go
@@ -158,6 +158,10 @@ func (o *Options) Run() error {
 			return false, fmt.Errorf("unable to get ExtendedDaemonSet, err: %w", err)
 		}
 
+		if eds.Status.State == v1alpha1.ExtendedDaemonSetStatusStateCanaryFailed {
+			return false, fmt.Errorf("canary marked as failed")
+		}
+
 		if eds.Status.Canary != nil {
 			o.printOutf("canary running")
 

--- a/cmd/check-eds/upgrade/upgrade.go
+++ b/cmd/check-eds/upgrade/upgrade.go
@@ -158,6 +158,12 @@ func (o *Options) Run() error {
 			return false, fmt.Errorf("unable to get ExtendedDaemonSet, err: %w", err)
 		}
 
+		if eds.Status.Canary != nil {
+			o.printOutf("canary running")
+
+			return false, nil
+		}
+
 		// We need to look at the activeReplicaSet of the current ExtendedDaemonSet object, and look at the creationTimestamp of
 		// that replicaset. If the creationTimestamp is older than the last occurrance of the "CanaryFailed" condition of the ExtendedDaemonSet,
 		// it is safe to assume that the canary failed and we should fail this check.
@@ -179,12 +185,6 @@ func (o *Options) Run() error {
 					return false, fmt.Errorf("active canary has a creation timestamp before the last CanaryFailed condition, meaning the deployment failed")
 				}
 			}
-		}
-
-		if eds.Status.Canary != nil {
-			o.printOutf("canary running")
-
-			return false, nil
 		}
 
 		if float64(eds.Status.UpToDate) > float64(eds.Status.Current)*o.nodeCompletionPct ||


### PR DESCRIPTION
### What does this PR do?

This PR checks the conditions within the EDS status field for the presence of the "Canary-Failed" condition, and compares its timestamp to the timestamp of the active replicaset to determine if the EDS canary failed or not

### Motivation

An agent version was deployed to staging that caused the canary to automatically fail due to a high number of restarts, but the check did not look at the canary status, so when desired replicas matched running replicas, the check succeeded, and we were none the wiser.

### Additional Notes

While testing the behavior, I noticed that the EDS object does not denote it has failed in any other way other than the conditions field. Here is the status field of an EDS object which had just failed:
```
status:
  activeReplicaSet: datadog-agent-tt9z6
  available: 30
  conditions:
    - lastTransitionTime: '2023-11-22T19:29:15Z'
      lastUpdateTime: '2023-11-22T19:29:15Z'
      message: 'canary failed with ers: datadog-agent-8n26h'
      reason: CanaryFailed
      status: 'False'
      type: Canary-Failed
    - lastTransitionTime: '2023-11-15T20:14:07Z'
      lastUpdateTime: '2023-11-15T20:14:07Z'
      message: 'canary paused with ers: datadog-agent-425pw'
      reason: CreateContainerConfigError
      status: 'False'
      type: Canary-Paused
  current: 33
  desired: 33
  ignoredUnresponsiveNodes: 0
  ready: 30
  state: Running
  upToDate: 23
```

Based on this example, I built the check to look at the conditions slice for the Canary-Failed type

### Describe your test plan

I have already deployed this change to a staging cluster, and have manually failed a deployment and was able to verify that the check failed with: `Error: active canary has a creation timestamp before the last CanaryFailed condition, meaning the deployment failed`

[Before change](https://sdp.ddbuild.io/#/deployments/details-tab?id=temporal%2Fdefault%7C%7Cregistry.ddbuild.io%2Fk8s-datadog-agent-ops%2Fworkflows%2Fdeploy_agents.snowver.us1.staging.dog-ExecuteWorkflow%7C%7C4bf30822-9a1f-410c-80eb-3d01f9ddfb64&viewOption=map)

[After change](https://sdp.ddbuild.io/#/deployments/details-tab?id=temporal%2Fdefault%7C%7Cregistry.ddbuild.io%2Fk8s-datadog-agent-ops%2Fworkflows%2Fdeploy_agents.snowver.us1.staging.dog%40sha256-ExecuteWorkflow%7C%7Cc83cb684-7ad7-4da9-b9ea-ddb154240e5b&viewOption=map)

The deployment values can be seen [here](https://github.com/DataDog/k8s-datadog-agent-ops/tree/sblumenthal/test-updated-eds-check)
