### PR TITLE
Update golangci-lint to v1.55.2

### DIFF
--- a/.golangci.toml
+++ b/.golangci.toml
@@ -74,7 +74,12 @@
     "gocritic",
     "errchkjson",
     "gofumpt",
-    "golint"
+    "golint",
+    "deadcode",
+    "structcheck",
+    "varcheck",
+    "unparam",
+    "depguard"
   ]
 
 [issues]

--- a/Makefile
+++ b/Makefile
@@ -193,7 +193,7 @@ bin/yq:
 	./hack/install-yq.sh 3.3.0
 
 bin/golangci-lint:
-	hack/install-golangci-lint.sh v1.52.2
+	hack/install-golangci-lint.sh v1.55.2
 
 bin/operator-sdk:
 	./hack/install-operator-sdk.sh v1.5.0

--- a/controllers/extendeddaemonsetreplicaset/strategy/rollingupdate_test.go
+++ b/controllers/extendeddaemonsetreplicaset/strategy/rollingupdate_test.go
@@ -9,6 +9,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -16,8 +18,6 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-
-	"github.com/stretchr/testify/assert"
 
 	datadoghqv1alpha1 "github.com/DataDog/extendeddaemonset/api/v1alpha1"
 )
@@ -319,7 +319,7 @@ func TestManageDeployment(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := ManageDeployment(client, tt.daemonset, tt.params, metaNow)
 			if !tt.wantErr {
-				assert.Nil(t, err, "ManageDeployment() error = %v", err)
+				require.NoError(t, err, "ManageDeployment() error = %v", err)
 			}
 			assert.Equal(t, tt.want, got)
 		})
@@ -502,7 +502,7 @@ func Test_getRollingUpdateStartTime(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := getRollingUpdateStartTime(tt.ersStatus, tt.time)
-			assert.Equal(t, got, tt.want)
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }

--- a/controllers/extendeddaemonsetreplicaset/strategy/utils_test.go
+++ b/controllers/extendeddaemonsetreplicaset/strategy/utils_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/types"
@@ -124,7 +125,7 @@ func Test_addPodLabel(t *testing.T) {
 			Name:      pod.Name,
 		}
 		err := c.Get(context.TODO(), nNs, wantPod)
-		assert.Nilf(t, err, "error must be nil, err: %v", err)
+		require.NoErrorf(t, err, "error must be nil, err: %v", err)
 
 		if gotVal, ok := wantPod.Labels[key]; ok {
 			assert.Equal(t, val, gotVal)
@@ -198,7 +199,7 @@ func Test_deletePodLabel(t *testing.T) {
 			Name:      pod.Name,
 		}
 		err := c.Get(context.TODO(), nNs, wantPod)
-		assert.Nilf(t, err, "error must be nil, err: %v", err)
+		require.NoErrorf(t, err, "error must be nil, err: %v", err)
 		if _, ok := wantPod.Labels[key]; ok {
 			t.Fatalf("Label is present, pod: %#v", wantPod.Labels)
 		}
@@ -268,7 +269,7 @@ func Test_cleanupPods(t *testing.T) {
 	client := fake.NewClientBuilder().WithObjects(pod1).Build()
 
 	err := cleanupPods(client, logger, status, pods)
-	assert.Nilf(t, err, "error must be nil, err: %v", err)
+	require.NoErrorf(t, err, "error must be nil, err: %v", err)
 }
 
 func Test_manageUnscheduledPodNodes(t *testing.T) {
@@ -314,5 +315,5 @@ func Test_manageUnscheduledPodNodes(t *testing.T) {
 	}
 
 	nodes := manageUnscheduledPodNodes(pods)
-	assert.Equal(t, len(nodes), 1)
+	assert.Len(t, nodes, 1)
 }

--- a/pkg/controller/metrics/register.go
+++ b/pkg/controller/metrics/register.go
@@ -57,7 +57,7 @@ func (h *storesHandler) serveKsmHTTP(w http.ResponseWriter, r *http.Request) {
 		for _, m := range metrics {
 			_, err = expfmt.MetricFamilyToText(w, m)
 			if err != nil {
-				log.Error(err, "Unable to write metrics", "metricFamily", *m.Name)
+				log.Error(err, "Unable to write metrics", "metricFamily", m.GetName())
 			}
 		}
 	} else {

--- a/pkg/controller/utils/affinity/affinity_test.go
+++ b/pkg/controller/utils/affinity/affinity_test.go
@@ -133,12 +133,12 @@ func TestReplaceNodeNameNodeAffinity(t *testing.T) {
 func TestGetNodeNameFromAffinity(t *testing.T) {
 	// nil case
 	got := GetNodeNameFromAffinity(nil)
-	assert.Equal(t, got, "")
+	assert.Equal(t, "", got)
 
 	// empty case
 	affinity := &v1.Affinity{}
 	got = GetNodeNameFromAffinity(affinity)
-	assert.Equal(t, got, "")
+	assert.Equal(t, "", got)
 
 	// non-nil case
 	nodeName := "foo-node"
@@ -160,5 +160,5 @@ func TestGetNodeNameFromAffinity(t *testing.T) {
 		},
 	}
 	got = GetNodeNameFromAffinity(affinity)
-	assert.Equal(t, got, "foo-node")
+	assert.Equal(t, "foo-node", got)
 }

--- a/pkg/controller/utils/comparison/comparison_test.go
+++ b/pkg/controller/utils/comparison/comparison_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -80,7 +81,7 @@ func TestGenerateMD5PodTemplateSpec(t *testing.T) {
 	ds = datadoghqv1alpha1.DefaultExtendedDaemonSet(ds, datadoghqv1alpha1.ExtendedDaemonSetSpecStrategyCanaryValidationModeAuto)
 	got, err := GenerateMD5PodTemplateSpec(&ds.Spec.Template)
 	assert.Equal(t, "a2bb34618483323482d9a56ae2515eed", got)
-	assert.Nil(t, err)
+	require.NoError(t, err)
 }
 
 func TestComparePodTemplateSpecMD5Hash(t *testing.T) {
@@ -120,7 +121,7 @@ func TestSetMD5PodTemplateSpecAnnotation(t *testing.T) {
 	ds := &datadoghqv1alpha1.ExtendedDaemonSet{}
 	got, err := SetMD5PodTemplateSpecAnnotation(rs, ds)
 	assert.Equal(t, "a2bb34618483323482d9a56ae2515eed", got)
-	assert.Nil(t, err)
+	require.NoError(t, err)
 }
 
 func Test_StringsContains(t *testing.T) {

--- a/pkg/controller/utils/pod/pod_test.go
+++ b/pkg/controller/utils/pod/pod_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -179,7 +180,7 @@ func TestGetNodeNameFromPod(t *testing.T) {
 	want := "node1"
 	got, err := GetNodeNameFromPod(pod)
 	assert.Equal(t, want, got)
-	assert.Nil(t, err)
+	require.NoError(t, err)
 
 	pod2 := ctrltest.NewPod("bar", "pod2", "", &ctrltest.NewPodOptions{
 		ContainerStatuses: []v1.ContainerStatus{
@@ -197,7 +198,7 @@ func TestGetNodeNameFromPod(t *testing.T) {
 	)
 	got, err = GetNodeNameFromPod(pod2)
 	assert.Equal(t, "", got)
-	assert.NotNil(t, err)
+	require.Error(t, err)
 }
 
 func TestIsPodReady(t *testing.T) {

--- a/pkg/plugin/canary/pause.go
+++ b/pkg/plugin/canary/pause.go
@@ -8,6 +8,7 @@ package canary
 import (
 	"context"
 	"fmt"
+	"strconv"
 
 	"github.com/spf13/cobra"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -187,7 +188,7 @@ func (o *pauseOptions) run() error {
 
 	patch := client.MergeFrom(eds)
 	if err = o.client.Patch(context.TODO(), newEds, patch); err != nil {
-		return fmt.Errorf("unable to %s ExtendedDaemonset deployment, err: %w", fmt.Sprintf("%v", o.pauseStatus), err)
+		return fmt.Errorf("unable to %s ExtendedDaemonset deployment, err: %w", strconv.FormatBool(o.pauseStatus), err)
 	}
 
 	fmt.Fprintf(o.Out, "ExtendedDaemonset '%s/%s' deployment paused set to %t\n", o.userNamespace, o.userExtendedDaemonSetName, o.pauseStatus)

--- a/pkg/plugin/common/utils.go
+++ b/pkg/plugin/common/utils.go
@@ -20,7 +20,7 @@ import (
 
 // IntToString converts int32 into string.
 func IntToString(i int32) string {
-	return fmt.Sprintf("%d", i)
+	return strconv.Itoa(int(i))
 }
 
 // GetDuration gets uptime duration of a resource.


### PR DESCRIPTION
### What does this PR do?

* Bump `golangci-lint` to v1.55.2 to support go v1.21
* Fix linter errors
* Disable deprecated linters (deadcode, structcheck, varcheck)
* Disable unparam and depguard linters

### Motivation

Building the `kubectl-eds` plugin was broken in go v1.21

### Additional Notes

* Disabled `unparam` linter to suppress `is always nil` error from the EDS controller function [`updateInstanceWithCurrentRS`](https://github.com/DataDog/extendeddaemonset/blob/b53e1cdba19da5b87ae2d6f90eeb6afe1764b7d7/controllers/extendeddaemonset/controller.go#L228) which returns a nil `reconcile.Result{}`. Called here https://github.com/DataDog/extendeddaemonset/blob/b53e1cdba19da5b87ae2d6f90eeb6afe1764b7d7/controllers/extendeddaemonset/controller.go#L151
* Disabled `depguard` linter to allow package imports

### Describe your test plan

Write there any instructions and details you may have to test your PR.
