### PR TITLE
[CONTINT-3761] Use GBI for the internal eds-check image

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -204,7 +204,7 @@ trigger_internal_eds_check_image:
     branch: master
     strategy: depend
   variables:
-    IMAGE_VERSION: tmpl-v2
+    IMAGE_VERSION: tmpl-v3
     IMAGE_NAME: $PROJECTNAME_CHECK
     RELEASE_TAG: ${CI_COMMIT_REF_SLUG}
     BUILD_TAG: ${CI_COMMIT_REF_SLUG}


### PR DESCRIPTION
### What does this PR do?

Migrate the internal `extendeddaemonset-check` image to GBI.

### Motivation

Security folks want all containers running on our internal infra to be based on a GBI golden base image.

### Additional Notes

See DataDog/images#5091.
The idea is to use GBI for the internal image only and to keep UBI as today for the public one.
As the binary is a standalone statically-linked file, it shouldn’t make any difference.

### Describe your test plan

Update the version of `extendeddaemonset-check` in [`k8s-datadog-agent-ops`](https://github.com/DataDog/k8s-datadog-agent-ops/blob/c178fcb76bbf555f8159b91bf0bf68ad46936473/k8s/datadog-agent/values/common-base.yaml#L56) and check that deployments are still working fine.
