### PR TITLE
fix several logs format issue issues

### DIFF
--- a/main.go
+++ b/main.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/client-go/discovery"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
+	klog "k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
 	ctrlzap "sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -46,6 +47,8 @@ var (
 )
 
 func init() {
+	klog.SetLogger(ctrl.Log.WithName("klog"))
+
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 
 	utilruntime.Must(datadoghqv1alpha1.AddToScheme(scheme))
@@ -220,7 +223,9 @@ func customSetupLogging(logLevel zapcore.Level, logEncoder string) error {
 	ctrl.SetLogger(ctrlzap.New(
 		ctrlzap.Encoder(encoder),
 		ctrlzap.Level(logLevel),
-		ctrlzap.StacktraceLevel(zapcore.PanicLevel)),
+		ctrlzap.StacktraceLevel(zapcore.PanicLevel),
+		ctrlzap.WriteTo(os.Stdout),
+	),
 	)
 
 	return nil

--- a/main.go
+++ b/main.go
@@ -210,12 +210,16 @@ func customSetupMetrics(mgr manager.Manager) {
 }
 
 func customSetupLogging(logLevel zapcore.Level, logEncoder string) error {
+	encoderConfig := zap.NewProductionEncoderConfig()
+	encoderConfig.EncodeLevel = zapcore.CapitalLevelEncoder
+	encoderConfig.EncodeTime = zapcore.RFC3339TimeEncoder
+
 	var encoder zapcore.Encoder
 	switch logEncoder {
 	case "console":
-		encoder = zapcore.NewConsoleEncoder(zap.NewProductionEncoderConfig())
+		encoder = zapcore.NewConsoleEncoder(encoderConfig)
 	case "json":
-		encoder = zapcore.NewJSONEncoder(zap.NewProductionEncoderConfig())
+		encoder = zapcore.NewJSONEncoder(encoderConfig)
 	default:
 		return fmt.Errorf("unknow log encoder: %s", logEncoder)
 	}

--- a/main.go
+++ b/main.go
@@ -229,8 +229,7 @@ func customSetupLogging(logLevel zapcore.Level, logEncoder string) error {
 		ctrlzap.Level(logLevel),
 		ctrlzap.StacktraceLevel(zapcore.PanicLevel),
 		ctrlzap.WriteTo(os.Stdout),
-	),
-	)
+	))
 
 	return nil
 }


### PR DESCRIPTION
### What does this PR do?

- redirect klog to the zap logger
- Use RFC3339 for the logs timestamp format

the logs coming from some kubernetes library are not properly formated, they are in plane text instead of json.
They are coming from the klog logger package.

```{"level":"dpanic","ts":1712850675.013771,"logger":"setup","msg":"odd number of arguments passed as key-value pairs for logging","ignored key":"datadog-agent"}
{"level":"info","ts":1712850675.0137613,"logger":"setup","msg":"Manager will be watching namespace"}
I0411 15:51:16.064096       1 request.go:665] Waited for 1.0406339s due to client-side throttling, not priority and fairness, request: GET:https://172.17.0.1:443/apis/externaldata.gatekeeper.sh/v1alpha1?timeout=32s
{"level":"info","ts":1712850676.317192,"logger":"controller-runtime.metrics","msg":"Metrics server is starting to listen","addr":":8080"}
{"level":"info","ts":1712850676.3222606,"logger":"setup","msg":"starting manager"}
{"level":"info","ts":1712850676.3232477,"msg":"Starting server","path":"/metrics","kind":"metrics","addr":"0.0.0.0:8080"}
{"level":"info","ts":1712850676.323306,"msg":"Starting server","kind":"health probe","addr":"0.0.0.0:8081"}
I0411 15:51:16.323362       1 leaderelection.go:248] attempting to acquire leader lease datadog-agent/extendeddaemonset-lock...
```
to resolved this issue this PR configure the klog package to use the zap logger configuration like for other logs line in the eds controller.

### Motivation

Use the same logs line format for all controller logs. 

### Additional Notes

we have equivalent fix int the [datadog-operator](https://github.com/DataDog/datadog-operator/blob/b167d8d51ab7a1d63a75a282378542fae9904fc9/main.go#L367-L369) and [WPA controller](https://github.com/DataDog/watermarkpodautoscaler/pull/92/files)code base 
### Describe your test plan

Start the controller with the option to output logs in json
expected behavior: all logs line should be in json format
