### PR TITLE
Use `docker buildx` to tag and push image for tagged commit

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -61,7 +61,7 @@ build_eds_image_amd64:
     - aws ssm get-parameter --region us-east-1 --name ci.extendeddaemonset.$DOCKER_REGISTRY_PWD_SSM_KEY --with-decryption --query "Parameter.Value" --out text | docker login --username "$DOCKER_REGISTRY_LOGIN" --password-stdin "$DOCKER_REGISTRY_URL"
   script:
     - IMG=$TARGET_IMAGE make docker-build-push-ci
-    - if [ -n "$CI_COMMIT_TAG" ]; then docker tag $TARGET_IMAGE $RELEASE_IMAGE && docker push $RELEASE_IMAGE; fi
+    - if [ -n "$CI_COMMIT_TAG" ]; then docker buildx imagetools create $TARGET_IMAGE --tag $RELEASE_IMAGE --push; fi
 
 build_eds_image_arm64:
   stage: image
@@ -78,7 +78,7 @@ build_eds_image_arm64:
     - aws ssm get-parameter --region us-east-1 --name ci.extendeddaemonset.$DOCKER_REGISTRY_PWD_SSM_KEY --with-decryption --query "Parameter.Value" --out text | docker login --username "$DOCKER_REGISTRY_LOGIN" --password-stdin "$DOCKER_REGISTRY_URL"
   script:
     - IMG=$TARGET_IMAGE make docker-build-push-ci
-    - if [ -n "$CI_COMMIT_TAG" ]; then docker tag $TARGET_IMAGE $RELEASE_IMAGE && docker push $RELEASE_IMAGE; fi
+    - if [ -n "$CI_COMMIT_TAG" ]; then docker buildx imagetools create $TARGET_IMAGE --tag $RELEASE_IMAGE --push; fi
 
 
 build_eds_check_image_amd64:
@@ -96,7 +96,7 @@ build_eds_check_image_amd64:
     - aws ssm get-parameter --region us-east-1 --name ci.extendeddaemonset.$DOCKER_REGISTRY_PWD_SSM_KEY --with-decryption --query "Parameter.Value" --out text | docker login --username "$DOCKER_REGISTRY_LOGIN" --password-stdin "$DOCKER_REGISTRY_URL"
   script:
     - IMG_CHECK=$TARGET_IMAGE make docker-build-push-check-ci
-    - if [ -n "$CI_COMMIT_TAG" ]; then docker tag $TARGET_IMAGE $RELEASE_IMAGE && docker push $RELEASE_IMAGE; fi
+    - if [ -n "$CI_COMMIT_TAG" ]; then docker buildx imagetools create $TARGET_IMAGE --tag $RELEASE_IMAGE --push; fi
 
 build_eds_check_image_arm64:
   stage: image
@@ -113,7 +113,7 @@ build_eds_check_image_arm64:
     - aws ssm get-parameter --region us-east-1 --name ci.extendeddaemonset.$DOCKER_REGISTRY_PWD_SSM_KEY --with-decryption --query "Parameter.Value" --out text | docker login --username "$DOCKER_REGISTRY_LOGIN" --password-stdin "$DOCKER_REGISTRY_URL"
   script:
     - IMG_CHECK=$TARGET_IMAGE make docker-build-push-check-ci
-    - if [ -n "$CI_COMMIT_TAG" ]; then docker tag $TARGET_IMAGE $RELEASE_IMAGE && docker push $RELEASE_IMAGE; fi
+    - if [ -n "$CI_COMMIT_TAG" ]; then docker buildx imagetools create $TARGET_IMAGE --tag $RELEASE_IMAGE --push; fi
 
 
 publish_public_main:


### PR DESCRIPTION
### What does this PR do?

Trying to fix rc release failures by replacing 
> docker tag $TARGET_IMAGE $RELEASE_IMAGE && docker push $RELEASE_IMAGE

which tags and pushes current image if commit is tagged with a command using `docker buildx`

>  docker buildx imagetools create $TARGET_IMAGE --tag $RELEASE_IMAGE --push

latter is needed after this change https://github.com/DataDog/extendeddaemonset/pull/172/

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details you may have to test your PR.
