### PR TITLE
feat: add EDSS ref on related Pod's labels

### DIFF
--- a/api/v1alpha1/const.go
+++ b/api/v1alpha1/const.go
@@ -10,6 +10,10 @@ const (
 	ExtendedDaemonSetNameLabelKey = "extendeddaemonset.datadoghq.com/name"
 	// ExtendedDaemonSetReplicaSetNameLabelKey label key use to link a Pod to a ExtendedDaemonSetReplicaSet.
 	ExtendedDaemonSetReplicaSetNameLabelKey = "extendeddaemonsetreplicaset.datadoghq.com/name"
+	// ExtendedDaemonSetSettingNameLabelKey label key use to link a Pod to a ExtendedDaemonSetSetting name.
+	ExtendedDaemonSetSettingNameLabelKey = "extendeddaemonsetsetting.datadoghq.com/name"
+	// ExtendedDaemonSetSettingNamespaceLabelKey label key use to link a Pod to a ExtendedDaemonSetSetting namespace.
+	ExtendedDaemonSetSettingNamespaceLabelKey = "extendeddaemonsetsetting.datadoghq.com/namespace"
 	// ExtendedDaemonSetReplicaSetCanaryLabelKey label key used to identify canary Pods.
 	ExtendedDaemonSetReplicaSetCanaryLabelKey = "extendeddaemonsetreplicaset.datadoghq.com/canary"
 	// ExtendedDaemonSetReplicaSetCanaryLabelValue label value used to identify canary Pods.

--- a/pkg/controller/utils/pod/create.go
+++ b/pkg/controller/utils/pod/create.go
@@ -85,6 +85,12 @@ func overwriteResourcesFromEdsNode(template *corev1.PodTemplateSpec, edsNode *da
 			}
 		}
 	}
+	// Add ExtendedDaemonsetSetting name and namespace as label on the pod to be able to filter on it
+	if template.Labels == nil {
+		template.Labels = map[string]string{}
+	}
+	template.Labels[datadoghqv1alpha1.ExtendedDaemonSetSettingNameLabelKey] = edsNode.GetName()
+	template.Labels[datadoghqv1alpha1.ExtendedDaemonSetSettingNamespaceLabelKey] = edsNode.GetNamespace()
 }
 
 func overwriteResourcesFromNode(template *corev1.PodTemplateSpec, edsNamespace, edsName string, node *corev1.Node) error {


### PR DESCRIPTION
### What does this PR do?

Add 2 new labels on pods when they are linked to an `ExtendedDaemonsetSettings` resource.
* `extendeddaemonsetsetting.datadoghq.com/name`
* `extendeddaemonsetsetting.datadoghq.com/namespace`

### Motivation

the goal is to allow pods filtering by ExtendedDaemonsetSettings name/ns.

### Additional Notes

We use Labels and not annotations because we would like to be able to do pods query filtering like
```
kubectl get pod -l extendeddaemonsetsetting.datadoghq.com/name=foo -l extendeddaemonsetsetting.datadoghq.com/namespace=bar
```

### Describe your test plan

Deploy an EDS and EDSS resource. on the pods linked to the EDSS the Pod labels should contains the 2 new labels.
