### PR TITLE
[CONTINT-4141] Schedule EDS Canaries on Healthy Agent

### DIFF
--- a/controllers/extendeddaemonset/controller.go
+++ b/controllers/extendeddaemonset/controller.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"fmt"
 	"math/rand"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -268,7 +269,7 @@ func (r *Reconciler) updateInstanceWithCurrentRS(logger logr.Logger, now time.Ti
 			}
 
 			if nbCanaryPod != len(newDaemonset.Status.Canary.Nodes) {
-				if err = r.selectNodes(logger, &newDaemonset.Spec, upToDate, newDaemonset.Status.Canary); err != nil {
+				if err = r.selectNodes(logger, daemonset, &newDaemonset.Spec, upToDate, newDaemonset.Status.Canary); err != nil {
 					logger.Error(err, "unable to select Nodes for canary")
 
 					return newDaemonset, reconcile.Result{}, err
@@ -310,9 +311,33 @@ func (r *Reconciler) updateInstanceWithCurrentRS(logger logr.Logger, now time.Ti
 	return newDaemonset, reconcile.Result{}, nil
 }
 
-func (r *Reconciler) selectNodes(logger logr.Logger, daemonsetSpec *datadoghqv1alpha1.ExtendedDaemonSetSpec, replicaset *datadoghqv1alpha1.ExtendedDaemonSetReplicaSet, canaryStatus *datadoghqv1alpha1.ExtendedDaemonSetStatusCanary) error {
+func (r *Reconciler) selectNodes(logger logr.Logger, daemonset *datadoghqv1alpha1.ExtendedDaemonSet, daemonsetSpec *datadoghqv1alpha1.ExtendedDaemonSetSpec, replicaset *datadoghqv1alpha1.ExtendedDaemonSetReplicaSet, canaryStatus *datadoghqv1alpha1.ExtendedDaemonSetStatusCanary) error {
 	// create a Fake pod from the current replicaset.spec.template
 	newPod, _ := podutils.CreatePodFromDaemonSetReplicaSet(r.scheme, replicaset, nil, nil, false)
+
+	// Get list of pods in extendeddaemonset
+	podList := &corev1.PodList{}
+	podSelector := labels.Set{datadoghqv1alpha1.ExtendedDaemonSetNameLabelKey: daemonset.Name}
+	podListOptions := []client.ListOption{
+		client.MatchingLabelsSelector{
+			Selector: podSelector.AsSelectorPreValidated(),
+		},
+	}
+	if err := r.client.List(context.TODO(), podList, podListOptions...); err != nil {
+		return err
+	}
+
+	// Count number of restarts per node
+	var nodeNameRestarts = make(map[string]int)
+
+	for _, pod := range podList.Items {
+		nodeName := pod.Spec.NodeName
+		podRestartCount := 0
+		for _, container := range pod.Status.ContainerStatuses {
+			podRestartCount += int(container.RestartCount)
+		}
+		nodeNameRestarts[nodeName] += podRestartCount
+	}
 
 	nodeList := &corev1.NodeList{}
 
@@ -340,6 +365,11 @@ func (r *Reconciler) selectNodes(logger logr.Logger, daemonsetSpec *datadoghqv1a
 	if err != nil {
 		return err
 	}
+
+	// Sort node list to prioritize nodes with least number of restarts
+	sort.Slice(nodeList.Items, func(i, j int) bool {
+		return nodeNameRestarts[nodeList.Items[i].Name] < nodeNameRestarts[nodeList.Items[j].Name]
+	})
 
 	// Filter Nodes Unschedulable
 	for _, node := range nodeList.Items {


### PR DESCRIPTION
### What does this PR do?

Prioritizes scheduling canaries on healthy agents by tracking the number of pod restarts on available nodes.

### Motivation

Deploys often fail because of trace-agent and system-probe restarts on a specific agent. Rather than randomly selecting available nodes and scheduling the canary on an agent in a potentially bad state, we can prioritize scheduling the canaries on nodes with the least number of restarts.

This should cause less deploys to fail due to the canaries going on bad agents.

### Additional Notes

### Describe your test plan

- Unit Testing:
  - Added a function `TestReconciler_selectNodes_prioritizingLeastRestarts` in `controller_test.go`.
  - Checks various scenarios to make sure the node with the least restarts is prioritized when applicable
  - Checks that specified canary nodes are scheduled first
- QA:
  - Create a kind cluster with at least 3 nodes
  - Run `make install` and `make deploy`
  - Create an EDS with the following description
```
apiVersion: datadoghq.com/v1alpha1
kind: ExtendedDaemonSet
metadata:
  name: mynginx
spec:
  strategy:
    canary:
      replicas: 1
      duration: 5m
      autoFail:
        enabled: true
        canaryTimeout: 10m
      autoPause:
        enabled: true
        maxRestarts: 5
    rollingUpdate:
      maxParallelPodCreation: 1
      maxUnavailable: 2
      slowStartIntervalDuration: 1m
  template:
    metadata:
      name: mynginx
      labels:
        app: mynginx
    spec:
      containers:
        - name: mynginx-minute
          image: nginx:latest
          imagePullPolicy: IfNotPresent
          args:
            - /bin/bash
            - '-c'
            - if [ $((1 + $RANDOM % 10)) -ge 4 ]; then sleep 20; echo hello; else sleep 9000; echo hi; fi;
```

   -
     - The containers on each pod will generate a random number and either restart after 20 seconds or run for 2.5 hours
     - After a few minutes, some pods will end up with more restarts than others (unless very unlucky)
     - Useful to run `kubectl get pods -o wide` to see what nodes each pod is running on and the number of restarts per node
     - Make an insignificant change to the `.yaml` file describing the EDS and apply those changes. (I changed `echo hi` to `echo hii`).
     - Using `kubectl get pods` and `kubectl get eds`, I made sure the canary always terminated the pod on the expected node.
     - The canary should always schedule to the node with the least number of restarts or tied for the least number of restarts
     - Ran the test with various numbers of workers, canary replicas, and parallel pod creation specs
