### PR TITLE
Add back `/ksmetrics` endpoint removed in #186

### DIFF
--- a/controllers/extendeddaemonset/metrics.go
+++ b/controllers/extendeddaemonset/metrics.go
@@ -6,8 +6,8 @@
 package extendeddaemonset
 
 import (
+	"k8s.io/apimachinery/pkg/runtime"
 	ksmetric "k8s.io/kube-state-metrics/pkg/metric"
-	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	datadoghqv1alpha1 "github.com/DataDog/extendeddaemonset/api/v1alpha1"
 	"github.com/DataDog/extendeddaemonset/controllers/extendeddaemonset/conditions"
@@ -35,8 +35,8 @@ func init() {
 	metrics.RegisterHandlerFunc(addMetrics)
 }
 
-func addMetrics(mgr manager.Manager, h metrics.Handler) error {
-	return metrics.AddMetrics(datadoghqv1alpha1.GroupVersion.WithKind("ExtendedDaemonSet"), mgr, h, generateMetricFamilies())
+func addMetrics(scheme *runtime.Scheme, h metrics.Handler) error {
+	return metrics.AddMetrics(datadoghqv1alpha1.GroupVersion.WithKind("ExtendedDaemonSet"), scheme, h, generateMetricFamilies())
 }
 
 func generateMetricFamilies() []ksmetric.FamilyGenerator {

--- a/controllers/extendeddaemonsetreplicaset/metrics.go
+++ b/controllers/extendeddaemonsetreplicaset/metrics.go
@@ -6,8 +6,8 @@
 package extendeddaemonsetreplicaset
 
 import (
+	"k8s.io/apimachinery/pkg/runtime"
 	ksmetric "k8s.io/kube-state-metrics/pkg/metric"
-	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	datadoghqv1alpha1 "github.com/DataDog/extendeddaemonset/api/v1alpha1"
 	"github.com/DataDog/extendeddaemonset/controllers/extendeddaemonsetreplicaset/conditions"
@@ -30,8 +30,8 @@ func init() {
 	metrics.RegisterHandlerFunc(addMetrics)
 }
 
-func addMetrics(mgr manager.Manager, h metrics.Handler) error {
-	return metrics.AddMetrics(datadoghqv1alpha1.GroupVersion.WithKind("ExtendedDaemonSetReplicaSet"), mgr, h, generateMetricFamilies())
+func addMetrics(scheme *runtime.Scheme, h metrics.Handler) error {
+	return metrics.AddMetrics(datadoghqv1alpha1.GroupVersion.WithKind("ExtendedDaemonSetReplicaSet"), scheme, h, generateMetricFamilies())
 }
 
 func generateMetricFamilies() []ksmetric.FamilyGenerator {


### PR DESCRIPTION
### What does this PR do?

Adding back `/ksmetrics` with a minor refactor. Current controller-runtime version takes endpoints during manager construction, while existing registration functions relied on manager being available.  

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details you may have to test your PR.
