### PR TITLE
add gitlab jobs triggered by conductor

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -8,6 +8,8 @@ variables:
   DOCKER_REGISTRY_LOGIN_SSM_KEY: docker_hub_login
   DOCKER_REGISTRY_PWD_SSM_KEY: docker_hub_pwd
   DOCKER_REGISTRY_URL: docker.io
+  # This should get updated to slug of latest release by make bundle command
+  CONDUCTOR_BUILD_TAG: v0-10-0-rc-6
 cache:
   key: ${CI_COMMIT_REF_SLUG}
   paths:
@@ -187,6 +189,27 @@ trigger_internal_eds_image:
     RELEASE_STAGING: "true"
     RELEASE_PROD: "true"
 
+trigger_internal_eds_image_conductor:
+  stage: release
+  rules:
+    - if: '$DDR == "true"'
+    - when: never
+  needs:
+    - build_eds_image_arm64
+    - build_eds_image_amd64
+  trigger:
+    project: DataDog/images
+    branch: master
+    strategy: depend
+  variables:
+    IMAGE_VERSION: tmpl-v3
+    IMAGE_NAME: $PROJECTNAME
+    RELEASE_TAG: ${CONDUCTOR_BUILD_TAG}
+    BUILD_TAG: ${CONDUCTOR_BUILD_TAG}
+    TMPL_SRC_IMAGE: v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}
+    RELEASE_STAGING: "true"
+    RELEASE_PROD: "true"
+
 trigger_internal_eds_check_image:
   stage: release
   rules:
@@ -204,6 +227,27 @@ trigger_internal_eds_check_image:
     IMAGE_NAME: $PROJECTNAME_CHECK
     RELEASE_TAG: ${CI_COMMIT_REF_SLUG}
     BUILD_TAG: ${CI_COMMIT_REF_SLUG}
+    TMPL_SRC_IMAGE: v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}
+    RELEASE_STAGING: "true"
+    RELEASE_PROD: "true"
+
+trigger_internal_eds_check_image_conductor:
+  stage: release
+  rules:
+    - if: '$DDR == "true"'
+    - when: never
+  needs:
+    - build_eds_check_image_arm64
+    - build_eds_check_image_amd64
+  trigger:
+    project: DataDog/images
+    branch: master
+    strategy: depend
+  variables:
+    IMAGE_VERSION: tmpl-v3
+    IMAGE_NAME: $PROJECTNAME_CHECK
+    RELEASE_TAG: ${CONDUCTOR_BUILD_TAG}
+    BUILD_TAG: ${CONDUCTOR_BUILD_TAG}
     TMPL_SRC_IMAGE: v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}
     RELEASE_STAGING: "true"
     RELEASE_PROD: "true"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -9,7 +9,7 @@ variables:
   DOCKER_REGISTRY_PWD_SSM_KEY: docker_hub_pwd
   DOCKER_REGISTRY_URL: docker.io
   # This should get updated to slug of latest release by make bundle command
-  CONDUCTOR_BUILD_TAG: v0-10-0-rc-6
+  CONDUCTOR_BUILD_TAG: v0-10-0-rc-8
 cache:
   key: ${CI_COMMIT_REF_SLUG}
   paths:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -208,7 +208,8 @@ trigger_internal_eds_image_conductor:
     BUILD_TAG: ${CONDUCTOR_BUILD_TAG}
     TMPL_SRC_IMAGE: v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}
     RELEASE_STAGING: "true"
-    RELEASE_PROD: "true"
+    # Temporary
+    RELEASE_PROD: "false"
 
 trigger_internal_eds_check_image:
   stage: release
@@ -250,4 +251,5 @@ trigger_internal_eds_check_image_conductor:
     BUILD_TAG: ${CONDUCTOR_BUILD_TAG}
     TMPL_SRC_IMAGE: v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}
     RELEASE_STAGING: "true"
-    RELEASE_PROD: "true"
+    # Temporary
+    RELEASE_PROD: "false"

--- a/Makefile
+++ b/Makefile
@@ -141,7 +141,7 @@ endif
 
 # Generate bundle manifests and metadata, then validate generated files.
 .PHONY: bundle
-bundle: manifests bin/kustomize
+bundle: manifests bin/kustomize patch-gitlab
 	./bin/operator-sdk generate kustomize manifests -q
 	cd config/manager && $(ROOT_DIR)/bin/kustomize edit set image controller=$(IMG)
 	./bin/kustomize build config/manifests | ./bin/operator-sdk generate bundle -q --overwrite --version $(BUNDLE_VERSION) $(BUNDLE_METADATA_OPTS)
@@ -165,6 +165,10 @@ generate-openapi: bin/openapi-gen
 .PHONY: patch-crds
 patch-crds: bin/yq
 	./hack/patch-crds.sh
+
+.PHONY: patch-gitlab
+patch-gitlab:
+	./hack/patch-gitlab.sh $(VERSION)
 
 .PHONY: lint
 lint: bin/golangci-lint fmt vet

--- a/hack/os-env.sh
+++ b/hack/os-env.sh
@@ -9,7 +9,12 @@ uname_os() {
 }
 
 OS=$(uname_os)
-SED="sed -i"
-if [ "$OS" == "darwin" ]; then
-    SED="sed -i .bak"
+ARCH=$(uname -m)
+PLATFORM="$OS-$ARCH"
+ROOT=$(git rev-parse --show-toplevel)
+export SED="sed -i"
+if [ "$PLATFORM" == "darwin-arm64" ]; then
+    export SED="sed -i ''"
+elif [ "$OS" == "darwin" ]; then
+    export SED="sed -i .bak"
 fi

--- a/hack/patch-gitlab.sh
+++ b/hack/patch-gitlab.sh
@@ -6,9 +6,10 @@ SCRIPTS_DIR="$(dirname "$0")"
 source "$SCRIPTS_DIR/os-env.sh"
 
 ROOT_DIR=$(git rev-parse --show-toplevel)
-FILE_PATH=$ROOT_DIR/.gitlab-ci.yml 
+GITLAB_FILE_PATH=$ROOT_DIR/.gitlab-ci.yml
+SERVICE_FILE_PATH=$ROOT_DIR/service.datadog.yaml
 
-# read arg as VERSION
+# Read arg as VERSION
 VERSION=$1
 
 if [ -z "$VERSION" ];
@@ -17,7 +18,12 @@ then
   exit 1
 fi
 
+# Update CONDUCTOR_BUILD_TAG envvar in Gitlab file, which is used in Conductor-triggered image build jobs
 # Replace . with -, add v
-VERSION=v$(echo $VERSION | sed "s/\./-/g")
+VERSION_SLUG=v$(echo $VERSION | sed "s/\./-/g")
 # Update envvar in Gitlab file
-$SED "s/CONDUCTOR_BUILD_TAG: .*$/CONDUCTOR_BUILD_TAG: $VERSION/g" $FILE_PATH
+$SED "s/CONDUCTOR_BUILD_TAG: .*$/CONDUCTOR_BUILD_TAG: $VERSION_SLUG/g" $GITLAB_FILE_PATH
+
+# Update branch that runs Conductor job, add v
+BRANCH=v$(echo $VERSION | sed -r "s/([^.]+.[^.]*).*/\1/")
+$SED "s/branch: .*$/branch: \"$BRANCH\"/g" $SERVICE_FILE_PATH

--- a/hack/patch-gitlab.sh
+++ b/hack/patch-gitlab.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -e
+
+SCRIPTS_DIR="$(dirname "$0")"
+source "$SCRIPTS_DIR/os-env.sh"
+
+ROOT_DIR=$(git rev-parse --show-toplevel)
+FILE_PATH=$ROOT_DIR/.gitlab-ci.yml 
+
+# read arg as VERSION
+VERSION=$1
+
+if [ -z "$VERSION" ];
+then
+  echo "usage: hack/patch-gitlab.sh <version>"
+  exit 1
+fi
+
+# Replace . with -, add v
+VERSION=v$(echo $VERSION | sed "s/\./-/g")
+# Update envvar in Gitlab file
+$SED "s/CONDUCTOR_BUILD_TAG: .*$/CONDUCTOR_BUILD_TAG: $VERSION/g" $FILE_PATH


### PR DESCRIPTION
### What does this PR do?

Add two Gitlab jobs that will be triggered by Conductor to rebuild images on a regular cadence

Add `make` command with a script that will update image name variable stored in Gitlab file

Small update to os-env.sh script

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan


There are a few ways to test. In all of them, make sure that the service.datadog.yaml `branch` parameter and .gitlab.ci.yaml `CONDUCTOR_BUILD_TAG` parameter are as expected.

```
./hack/patch-gitlab.sh 1.2.3

make patch-gitlab VERSION=100.200.300

make VERSION=11.12.13-rc.4 bundle
```
