### PR TITLE
Fix /debug/pprof endpoints + uniquely name controller + fix logging

### DIFF
--- a/controllers/podtemplate_controller.go
+++ b/controllers/podtemplate_controller.go
@@ -47,6 +47,7 @@ func (r *PodTemplateReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	r.internal = internal
 
 	return ctrl.NewControllerManagedBy(mgr).
+		Named("eds_podtemplate").
 		For(&datadoghqv1alpha1.ExtendedDaemonSet{}).
 		Owns(&corev1.PodTemplate{}).
 		Complete(r)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -52,11 +52,11 @@ func ManagerOptionsWithNamespaces(logger logr.Logger, opt ctrl.Options) ctrl.Opt
 	case len(namespaces) == 0:
 		logger.Info("Manager will watch and manage resources in all namespaces")
 	case len(namespaces) == 1:
-		logger.Info("Manager will be watching namespace", namespaces[0])
+		logger.Info("Manager will be watching namespace", "namespace", namespaces[0])
 		opt.Cache.DefaultNamespaces = map[string]cache.Config{namespaces[0]: {}}
 	case len(namespaces) > 1:
 		// configure cluster-scoped with MultiNamespacedCacheBuilder
-		logger.Info("Manager will be watching multiple namespaces", namespaces)
+		logger.Info("Manager will be watching multiple namespaces", "namespaces", namespaces)
 		opt.NewCache = func(config *rest.Config, opts cache.Options) (cache.Cache, error) {
 			// https://github.com/kubernetes-sigs/controller-runtime/commit/3e35cab1ea29145d8699259b079633a2b8cfc116
 			nsConfigs := make(map[string]cache.Config)

--- a/pkg/controller/debug/register.go
+++ b/pkg/controller/debug/register.go
@@ -32,10 +32,18 @@ func DefaultOptions() *Options {
 // GetExtraMetricHandlers creates debug endpoints.
 func GetExtraMetricHandlers() map[string]http.Handler {
 	handlers := make(map[string]http.Handler)
-	handlers["debug/pprof"] = http.HandlerFunc(pprof.Index)
-	handlers["/debug/pprof/cmdline"] = http.HandlerFunc(pprof.Index)
-	handlers["/debug/pprof/cmdline"] = http.HandlerFunc(pprof.Index)
-	handlers["/debug/pprof/symobol"] = http.HandlerFunc(pprof.Index)
-	handlers["/debug/pprof/trace"] = http.HandlerFunc(pprof.Index)
+	// Root index (must include trailing slash for correct links)
+	handlers["/debug/pprof/"] = http.HandlerFunc(pprof.Index)
+	// Standard pprof endpoints
+	handlers["/debug/pprof/cmdline"] = http.HandlerFunc(pprof.Cmdline)
+	handlers["/debug/pprof/profile"] = http.HandlerFunc(pprof.Profile)
+	handlers["/debug/pprof/symbol"] = http.HandlerFunc(pprof.Symbol)
+	handlers["/debug/pprof/trace"] = http.HandlerFunc(pprof.Trace)
+	// Common profiles
+	handlers["/debug/pprof/heap"] = pprof.Handler("heap")
+	handlers["/debug/pprof/goroutine"] = pprof.Handler("goroutine")
+	handlers["/debug/pprof/block"] = pprof.Handler("block")
+	handlers["/debug/pprof/threadcreate"] = pprof.Handler("threadcreate")
+	handlers["/debug/pprof/allocs"] = pprof.Handler("allocs")
 	return handlers
 }


### PR DESCRIPTION
### What does this PR do?

* ac99bfc7ba6e8565c099eb910129c7c804c5706f: fixes pprof endpoints for debugging and gate them behind it being active
* 073487cb46d5eb99deb5f878a2e10da0a1b789eb: override inferred name for podtemplate controller
* 7293e493eb11e892adcb3e419c367212fed4a67d: use key/value expected format for logger

### Motivation (for each commit)

* debugging pprof requires being able to access it
* `{"level":"ERROR","ts":"2025-08-22T13:14:22Z","logger":"setup","msg":"unable to setup controllers","error":"unable to create controller PodTemplate: controller with name extendeddaemonset already exists. Controller names must be unique to avoid multiple controllers reporting to the same metric"}` : by default, the controller name will be using the object it watches, but we have both EDS and podtemplate watching the same objects (ERS is fine since it watches different object, so already unique)
    * This is required by controller-runtime 0.19 https://github.com/kubernetes-sigs/controller-runtime/releases/tag/v0.19.0
* `{"level":"DPANIC","ts":"2025-08-22T13:14:21Z","logger":"setup","msg":"odd number of arguments passed as key-value pairs for logging","ignored key":"default"}`

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

1. Build new version with `make docker-build`
2. Push it locally to your cluster
3. `make deploy` and reference your locally built image
4. Ensure:
    1. No more panic logs, but should see instead `{"level":"INFO","ts":"2025-08-22T13:21:29Z","logger":"setup","msg":"Manager will be watching namespace","namespace":"default"}`
    2. No more CLBO when starting it (the unable to setup controllers log should not be there)
    3. You can access `/debug/pprof` by port-forwarding `8080` and access all the individual pages 
<img width="1389" height="688" alt="image" src="https://github.com/user-attachments/assets/59434db1-2acf-41b4-ac29-42b380416c33" />


