### PR TITLE
Remove Docs Team as CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,5 +6,5 @@
 *                  @Datadog/container-ecosystems
 
 # Documentation
-README.md             @DataDog/documentation @Datadog/container-ecosystems
-/docs/                @DataDog/documentation @Datadog/container-ecosystems
+README.md             @Datadog/container-ecosystems
+/docs/                @Datadog/container-ecosystems


### PR DESCRIPTION
### What does this PR do?

Removes Docs as CODEOWNERS from the repo.

### Motivation

As part of a project to reduce courtesy reviews, the Docs Team is limiting CODEOWNERS entries to repos that single-source content into the docs site or where our review is critical. We’re still happy to review content if you reach out to us directly.

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details you may have to test your PR.
