### PR TITLE
Use recommended GetScaledValue and fix canary computation when using percentage

### DIFF
--- a/controllers/extendeddaemonset/controller.go
+++ b/controllers/extendeddaemonset/controller.go
@@ -256,7 +256,7 @@ func (r *Reconciler) updateInstanceWithCurrentRS(logger logr.Logger, now time.Ti
 
 		if isCanaryActive {
 			// manager CanaryNode selection.
-			nbCanaryPod, err := intstrutil.GetValueFromIntOrPercent(daemonset.Spec.Strategy.Canary.Replicas, int(daemonset.Status.Desired), true)
+			nbCanaryPod, err := intstrutil.GetScaledValueFromIntOrPercent(daemonset.Spec.Strategy.Canary.Replicas, int(daemonset.Status.Desired), true)
 			if err != nil {
 				logger.Error(err, "unable to select Nodes for canary")
 
@@ -361,7 +361,7 @@ func (r *Reconciler) selectNodes(logger logr.Logger, daemonset *datadoghqv1alpha
 		currentNodes = canaryStatus.Nodes
 	}
 
-	nbCanaryPod, err := intstrutil.GetValueFromIntOrPercent(daemonsetSpec.Strategy.Canary.Replicas, int(replicaset.Status.Desired), true)
+	nbCanaryPod, err := intstrutil.GetScaledValueFromIntOrPercent(daemonsetSpec.Strategy.Canary.Replicas, int(daemonset.Status.Desired), true)
 	if err != nil {
 		return err
 	}

--- a/controllers/extendeddaemonsetreplicaset/strategy/rollingupdate.go
+++ b/controllers/extendeddaemonsetreplicaset/strategy/rollingupdate.go
@@ -50,7 +50,7 @@ func ManageDeployment(client runtimeclient.Client, daemonset *datadoghqv1alpha1.
 
 	nbNodes := len(params.PodByNodeName)
 
-	maxPodSchedulerFailure, err := intstrutil.GetValueFromIntOrPercent(params.Strategy.RollingUpdate.MaxPodSchedulerFailure, nbNodes, true)
+	maxPodSchedulerFailure, err := intstrutil.GetScaledValueFromIntOrPercent(params.Strategy.RollingUpdate.MaxPodSchedulerFailure, nbNodes, true)
 	if err != nil {
 		params.Logger.Error(err, "unable to retrieve maxPodSchedulerFailure from the strategy.RollingUpdate.MaxPodSchedulerFailure parameter")
 
@@ -96,7 +96,7 @@ func ManageDeployment(client runtimeclient.Client, daemonset *datadoghqv1alpha1.
 	}
 
 	// Retrieves parameters for calculation
-	maxUnavailable, err := intstrutil.GetValueFromIntOrPercent(params.Strategy.RollingUpdate.MaxUnavailable, nbNodes, true)
+	maxUnavailable, err := intstrutil.GetScaledValueFromIntOrPercent(params.Strategy.RollingUpdate.MaxUnavailable, nbNodes, true)
 	if err != nil {
 		params.Logger.Error(err, "unable to retrieve maxUnavailable pod from the strategy.RollingUpdate.MaxUnavailable parameter")
 
@@ -221,7 +221,7 @@ func getRollingUpdateStartTime(status *datadoghqv1alpha1.ExtendedDaemonSetReplic
 }
 
 func calculateMaxCreation(params *datadoghqv1alpha1.ExtendedDaemonSetSpecStrategyRollingUpdate, nbNodes int, rsStartTime, now time.Time) (int, error) {
-	startValue, err := intstrutil.GetValueFromIntOrPercent(params.SlowStartAdditiveIncrease, nbNodes, true)
+	startValue, err := intstrutil.GetScaledValueFromIntOrPercent(params.SlowStartAdditiveIncrease, nbNodes, true)
 	if err != nil {
 		return 0, err
 	}


### PR DESCRIPTION
### What does this PR do?

* Uses `GetScaledValue` instead of `GetValue` as the latter was deprecated due to bug: https://pkg.go.dev/k8s.io/apimachinery@v0.28.9/pkg/util/intstr#GetValueFromIntOrPercent
* Uses EDS desired instead of ERS desired, the latter is computed after for canary, so when we use a %, we get % of 0 which is always 0, making the canary phase be skipped

### Motivation

* Fix internal deployment

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

* Tested by using 3% in a 3 nodes cluster and ensuring I get a single canary replica
