### PR TITLE
[tooling] Update pr linter job

### DIFF
--- a/.github/workflows/pr-linter.yml
+++ b/.github/workflows/pr-linter.yml
@@ -1,6 +1,6 @@
 name: pull request linter
 on:
-  pull_request_target:
+  pull_request:
    types: [opened, labeled, unlabeled, synchronize]
 
 permissions: {}

--- a/.github/workflows/pr-linter.yml
+++ b/.github/workflows/pr-linter.yml
@@ -1,6 +1,6 @@
 name: pull request linter
 on:
-  pull_request:
+  pull_request_target:
    types: [opened, labeled, unlabeled, synchronize]
 
 permissions: {}
@@ -10,12 +10,12 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: write
+      pull-requests: read
     steps:
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v1
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: Verify Pull Request Labels
-      uses: jesusvasquez333/verify-pr-label-action@v1.4.0
+      uses: jesusvasquez333/verify-pr-label-action@657d111bbbe13e22bbd55870f1813c699bde1401 # v1.4.0
       with:
         github-token: '${{ secrets.GITHUB_TOKEN }}'
         valid-labels: 'bug, enhancement, documentation, tooling'


### PR DESCRIPTION
### What does this PR do?

- PR linter job fails on forked PRs, blocking merge. For example https://github.com/DataDog/extendeddaemonset/pull/218
- Pin github actions by SHA
- pull request write permissions aren't needed

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

jobs run on `pull_request` trigger [d6f0d00](https://github.com/DataDog/extendeddaemonset/pull/222/commits/d6f0d00fd42cc988f0b0a64ff8e307f1c8c899b9): https://github.com/DataDog/extendeddaemonset/actions/runs/17563102036/job/49883971030?pr=222 https://github.com/DataDog/extendeddaemonset/actions/runs/17563102036/job/49883971010?pr=222

Added `pull_request_target` target (job will only run after merge to main)
