### PR TITLE
Include ERS status in `ers_status_current` metric

### DIFF
--- a/controllers/extendeddaemonsetreplicaset/metrics.go
+++ b/controllers/extendeddaemonsetreplicaset/metrics.go
@@ -102,6 +102,8 @@ func generateMetricFamilies() []generator.FamilyGenerator {
 			GenerateFunc: func(obj interface{}) *ksmetric.Family {
 				ers := obj.(*datadoghqv1alpha1.ExtendedDaemonSetReplicaSet)
 				labelKeys, labelValues := utils.GetLabelsValues(&ers.ObjectMeta)
+				labelKeys = append(labelKeys, "status")
+				labelValues = append(labelValues, ers.Status.Status)
 
 				return &ksmetric.Family{
 					Metrics: []*ksmetric.Metric{

--- a/controllers/extendeddaemonsetreplicaset/metrics.go
+++ b/controllers/extendeddaemonsetreplicaset/metrics.go
@@ -6,6 +6,8 @@
 package extendeddaemonsetreplicaset
 
 import (
+	"strings"
+
 	"k8s.io/apimachinery/pkg/runtime"
 	ksmetric "k8s.io/kube-state-metrics/v2/pkg/metric"
 	generator "k8s.io/kube-state-metrics/v2/pkg/metric_generator"
@@ -103,7 +105,7 @@ func generateMetricFamilies() []generator.FamilyGenerator {
 				ers := obj.(*datadoghqv1alpha1.ExtendedDaemonSetReplicaSet)
 				labelKeys, labelValues := utils.GetLabelsValues(&ers.ObjectMeta)
 				labelKeys = append(labelKeys, "status")
-				labelValues = append(labelValues, ers.Status.Status)
+				labelValues = append(labelValues, strings.ToLower(ers.Status.Status))
 
 				return &ksmetric.Family{
 					Metrics: []*ksmetric.Metric{


### PR DESCRIPTION
### What does this PR do?

* Fetches the ERS status and adds it as a label in the `ers_status_current` prometheus metric

### Motivation

* To distinguish between canary, unknown and active easily:
```shell
# HELP ers_status_current The number of nodes running at least one daemon pod and are supposed to.
# TYPE ers_status_current gauge
ers_status_current{namespace="datadog-agent",name="datadog-agent-jw9qx"} 5
```
**After**
```shell
# HELP ers_status_current The number of nodes running at least one daemon pod and are supposed to.
# TYPE ers_status_current gauge
ers_status_current{namespace="datadog-agent",name="datadog-agent-jw9qx", status="canary"} 5
```

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details you may have to test your PR.
