### PR TITLE
Add Datadog code coverage upload

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -13,6 +13,9 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write # needed for dd-sts OIDC token exchange
     steps:
     - name: Set up Go
       uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6.1.0
@@ -39,12 +42,18 @@ jobs:
         token: ${{ secrets.CODECOV_TOKEN }}
         file: cover.out
         flags: unittests
+    - name: Get Datadog credentials
+      id: dd-sts
+      continue-on-error: true
+      uses: DataDog/dd-sts-action@2e8187910199bd93129520183c093e19aa585c75 # v1.0.0
+      with:
+        policy: extendeddaemonset
     - name: Upload coverage to Datadog
-      if: always()
+      if: steps.dd-sts.outputs.api_key != ''
       continue-on-error: true
       uses: DataDog/coverage-upload-github-action@v1
       with:
-        api_key: ${{ secrets.DD_API_KEY }}
+        api_key: ${{ steps.dd-sts.outputs.api_key }}
         files: cover.out
         format: go-coverprofile
         flags: unittests

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -39,6 +39,15 @@ jobs:
         token: ${{ secrets.CODECOV_TOKEN }}
         file: cover.out
         flags: unittests
+    - name: Upload coverage to Datadog
+      if: always()
+      continue-on-error: true
+      uses: DataDog/coverage-upload-github-action@v1
+      with:
+        api_key: ${{ secrets.DD_API_KEY }}
+        files: cover.out
+        format: go-coverprofile
+        flags: unittests
   e2e:
     runs-on: ubuntu-latest
     strategy:

--- a/code-coverage.datadog.yml
+++ b/code-coverage.datadog.yml
@@ -1,0 +1,11 @@
+schema-version: v1
+ignore:
+  - "test/"
+  - "**/zz_generated.*.go"
+gates:
+  - type: patch_coverage_percentage
+    config:
+      threshold: 80
+flags:
+  unittests:
+    carryforward: false


### PR DESCRIPTION
## What does this PR do?

We're migrating Datadog repositories from Codecov to [Datadog Code Coverage](https://docs.datadoghq.com/code_analysis/code_coverage/) for tracking test coverage. This PR is the first step: it adds a Datadog coverage upload **alongside** the existing Codecov upload so we can run both systems in parallel and verify parity before switching over.

## Changes

- Added `DataDog/coverage-upload-github-action@v1` step to the `build` job in `validation.yml`, running after the existing Codecov upload
- Added `code-coverage.datadog.yml` with ignore paths (`test/`, `**/zz_generated.*.go`) and 80% patch coverage gate mirroring the Codecov config
- Coverage format: Go Coverprofile (`cover.out`) with `unittests` flag (mirroring Codecov)
- The existing Codecov uploads are **unchanged** — nothing is removed or modified
- The upload uses `if: always()` and `continue-on-error: true` so it cannot block CI

## Why are we doing this?

As part of a company-wide effort, we're consolidating code coverage reporting into Datadog's own Code Coverage product. This gives us:
- Coverage data integrated directly into Datadog CI Visibility
- PR gates and coverage checks natively in Datadog
- No dependency on a third-party service (Codecov) for coverage reporting

## Validation

Pending — requires `DD_API_KEY` secret to be configured in this repo. Coverage comparison will be possible once the secret is added.

## Next steps (not in this PR)

Once this PR is merged and we've confirmed Datadog coverage is stable over several commits:
1. Remove the Codecov upload steps and `CODECOV_TOKEN` secret
2. Remove `codecov.yml`
3. Optionally configure PR gates in `code-coverage.datadog.yml`

## No action needed from reviewers beyond normal review

This is a low-risk, additive change. The new upload step runs independently of the existing CI pipeline and cannot cause test failures.