### PR TITLE
Fix conductor branch to use current active release branch

### DIFF
--- a/service.datadog.yaml
+++ b/service.datadog.yaml
@@ -33,7 +33,7 @@ tags:
 extensions:
   datadoghq.com/sdp:
     conductor:
-      slack: "celene-test"
+      slack: "agent-onboarding-ops"
       options:
         rollout_strategy: "installation"
       targets:
@@ -45,7 +45,8 @@ extensions:
           parent_environments:
             - "staging"
           # Need automation to set this
-          branch: "v0.10"
+          # DO NOT FORGET TO UPDATE IF CHANGING RELEASE BRANCH
+          branch: "v0.11"
           # Run at 8am every 4 Mondays
           schedule: "0 8/672 * * 1"
           options:


### PR DESCRIPTION
### What does this PR do?

* Replaces conductor branch with current release `v0.11`

### Motivation

* Avoid building from older branch on very old commits: https://gitlab.ddbuild.io/DataDog/extendeddaemonset/-/commit/25bcb2d71d257897102c5cf3bd63e7f1d88525e1 / https://gitlab.ddbuild.io/DataDog/extendeddaemonset/-/pipelines/104969969 / https://mosaic.us1.ddbuild.io/services/details?name=extendeddaemonset&selectedTarget=horizon-build-test&service_tab=conductor&page=1

### Additional Notes

* This is updated automatically with `make bundle` command but we never ran it properly when moving to 0.11

### Describe your test plan

Write there any instructions and details you may have to test your PR.
