### PR TITLE
Rename agent-all to agent-community-eng

### DIFF
--- a/repository.datadog.yml
+++ b/repository.datadog.yml
@@ -3,7 +3,7 @@ schema-version: v1
 kind: mergequeue
 gitlab_check_enable: false
 github_teams_restrictions:
-  - agent-all
+  - agent-community-eng
   - container-ecosystems
   - container-integrations
   - container-platforms


### PR DESCRIPTION

### What does this PR do?

Rename agent-all to agent-community-eng for MQ access.

### Motivation

This GitHub team was renamed.
