### PR TITLE
Rename agent-all to agent-community-eng for MQ access

### DIFF
--- a/repository.datadog.yml
+++ b/repository.datadog.yml
@@ -3,7 +3,7 @@ schema-version: v1
 kind: mergequeue
 gitlab_check_enable: false
 github_teams_restrictions:
-  - agent-all
+  - agent-community-eng
   - container-ecosystems
   - container-integrations
   - container-platforms


### PR DESCRIPTION
### What does this PR do?

Rename agent-all to agent-community-eng for MQ access.

### Motivation

We've renamed this team.

### Additional Notes

Replaces https://github.com/DataDog/extendeddaemonset/pull/287 since that was a fork and so CI didn't run.

### Describe your test plan

Write there any instructions and details you may have to test your PR.
