### PR TITLE
[CONTP-2052] move CI to ddoghq/images instead of DataDog/images

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -205,7 +205,7 @@ trigger_internal_eds_image:
     - build_eds_image_arm64
     - build_eds_image_amd64
   trigger:
-    project: DataDog/images
+    project: ddoghq/images
     branch: master
     strategy: depend
   variables:
@@ -226,7 +226,7 @@ trigger_internal_eds_image_fips:
     - build_eds_image_arm64
     - build_eds_image_amd64
   trigger:
-    project: DataDog/images
+    project: ddoghq/images
     branch: master
     strategy: depend
   variables:
@@ -247,7 +247,7 @@ trigger_internal_eds_image_conductor:
     - build_eds_image_arm64
     - build_eds_image_amd64
   trigger:
-    project: DataDog/images
+    project: ddoghq/images
     branch: master
     strategy: depend
   variables:
@@ -270,7 +270,7 @@ trigger_internal_eds_check_image:
     - build_eds_check_image_arm64
     - build_eds_check_image_amd64
   trigger:
-    project: DataDog/images
+    project: ddoghq/images
     branch: master
     strategy: depend
   variables:
@@ -291,7 +291,7 @@ trigger_internal_eds_check_image_conductor:
     - build_eds_check_image_arm64
     - build_eds_check_image_amd64
   trigger:
-    project: DataDog/images
+    project: ddoghq/images
     branch: master
     strategy: depend
   variables:

--- a/service.datadog.yaml
+++ b/service.datadog.yaml
@@ -22,7 +22,7 @@ links:
     url: https://github.com/DataDog/k8s-datadog-agent-ops/tree/main/charts/extendeddaemonset
   - name: internal-image
     type: repo
-    url: https://github.com/DataDog/images/tree/master/extendeddaemonset
+    url: https://github.com/ddoghq/images/tree/master/extendeddaemonset
   - name: On Call documentation
     type: doc
     url: https://datadoghq.atlassian.net/wiki/spaces/ContEco/pages/2445645960/On+Call


### PR DESCRIPTION
### What does this PR do?

Updates CI pipeline to use `ddoghq/images` instead of `DataDog/images`

### Motivation

CI migration.

### Additional Notes

**_Do not merge yet_**
